### PR TITLE
Update caab-api version to 0.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ repositories {
 dependencies {
 	implementation 'uk.gov.laa.ccms.data:data-api:0.0.1'
 	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.4'
-	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.3-ae3ebda-SNAPSHOT'
+	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.3'
 
 	//Starters
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update caab-api version to 0.0.3