### PR TITLE
Amend workflows to use new service account token

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -33,7 +33,6 @@ jobs:
         run: echo "tag_name=${{ steps.extract_repo_name.outputs.repo_name }}-${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
         id: extract_tag_name
 
-
   build-test:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -47,10 +46,12 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Set up environment variables
-        env:
-          GIT_PACKAGE_KEY: ${{ secrets.GIT_PACKAGE_KEY }}
-        run: echo "GIT_PACKAGE_KEY=${GIT_PACKAGE_KEY}" >> $GITHUB_ENV
+      - name: Obtain service account token
+        run: |
+          npm install -g obtain-github-app-installation-access-token
+          TOKEN="$(npx obtain-github-app-installation-access-token ci ${{ secrets.GH_APP_CREDENTIALS_TOKEN }})"
+          echo "::add-mask::$TOKEN"
+          echo "CAAB_SERVICE_TOKEN=$TOKEN" >> $GITHUB_ENV
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
@@ -118,13 +119,21 @@ jobs:
     runs-on: ubuntu-latest
     environment: development
     steps:
+      - name: Obtain service account token
+        run: |
+          npm install -g obtain-github-app-installation-access-token
+          TOKEN="$(npx obtain-github-app-installation-access-token ci ${{ secrets.GH_APP_CREDENTIALS_TOKEN }})"
+          echo "::add-mask::$TOKEN"
+          echo "CAAB_SERVICE_TOKEN=$TOKEN" >> $GITHUB_ENV
+
       - name: Checkout charts repo
         uses: actions/checkout@v3
         with:
           repository: ministryofjustice/laa-ccms-caab-helm-charts
           ref: development
           path: laa-ccms-caab-helm-charts
-          token: ${{ secrets.REPO_TOKEN }}
+          token: ${{ env.CAAB_SERVICE_TOKEN }}
+
       - name: update helm chart
         env:
           IMAGE_TAG: ${{ needs.define-image-tag.outputs.tag_name }}

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -29,10 +29,12 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Set up environment variables
-        env:
-          GIT_PACKAGE_KEY: ${{ secrets.GIT_PACKAGE_KEY }}
-        run: echo "GIT_PACKAGE_KEY=${GIT_PACKAGE_KEY}" >> $GITHUB_ENV
+      - name: Obtain service account token
+        run: |
+          npm install -g obtain-github-app-installation-access-token
+          TOKEN="$(npx obtain-github-app-installation-access-token ci ${{ secrets.GH_APP_CREDENTIALS_TOKEN }})"
+          echo "::add-mask::$TOKEN"
+          echo "CAAB_SERVICE_TOKEN=$TOKEN" >> $GITHUB_ENV
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ if (file('secrets.gradle').exists()) {
 	gitPackageKey = project.ext.gitPackageKey
 } else {
 	gitPackageUser = 'laa-ccms-caab-ui'
-	gitPackageKey = System.getenv('GIT_PACKAGE_KEY')
+	gitPackageKey = System.getenv('CAAB_SERVICE_TOKEN')
 }
 
 repositories {


### PR DESCRIPTION
- Amended secrets to use GH_APP_CREDENTIALS_TOKEN
- Workflows now use obtain-github-app-installation-access-token to obtain service account token
- gradle build also change to use the service account token