### PR TITLE
Update soa-api version to 0.0.16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ repositories {
 
 dependencies {
 	implementation 'uk.gov.laa.ccms.data:data-api:0.0.5'
-	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.15'
+	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.16'
 	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.16'
 
 	compileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update soa-api version to 0.0.16