### PR TITLE
Update caab-api version to 0.0.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ repositories {
 dependencies {
 	implementation 'uk.gov.laa.ccms.data:data-api:0.0.5'
 	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.16'
-	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.20'
+	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.22'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update caab-api version to 0.0.22