### PR TITLE
Update assessment-api version to 0.0.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ dependencies {
 
 	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.20'
 
-	implementation 'uk.gov.laa.ccms.caab:assessment-api:0.0.6-24b5b7d-SNAPSHOT'
+	implementation 'uk.gov.laa.ccms.caab:assessment-api:0.0.6'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update assessment-api version to 0.0.6