### PR TITLE
Update soa-api version to 0.0.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ repositories {
 dependencies {
 	implementation 'uk.gov.laa.ccms.data:data-api:0.0.6'
 
-	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.16'
+	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.18'
 
 	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.22'
 


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update soa-api version to 0.0.18