### PR TITLE
Update assessment-api version to 0.0.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 
 	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.23-53f3fad-SNAPSHOT'
 
-	implementation 'uk.gov.laa.ccms.caab:assessment-api:0.0.6'
+	implementation 'uk.gov.laa.ccms.caab:assessment-api:0.0.9'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update assessment-api version to 0.0.9