### PR TITLE
Update caab-api version to 0.0.25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 
 	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.16'
 
-	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.23-53f3fad-SNAPSHOT'
+	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.25'
 
 	implementation 'uk.gov.laa.ccms.caab:assessment-api:0.0.6'
 


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update caab-api version to 0.0.25