### PR TITLE
Update caab-api version to 0.0.28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
 	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.23'
 
-	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.27'
+	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.28'
 
 	implementation 'uk.gov.laa.ccms.caab:assessment-api:0.0.12'
 


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update caab-api version to 0.0.28