### PR TITLE
Update soa-api version to 0.0.29

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
 	implementation 'uk.gov.laa.ccms.data:data-api:0.0.12'
 
-	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.27'
+	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.29'
 
 	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.31'
 


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update soa-api version to 0.0.29