### PR TITLE
Story (CCLS-2182) Submission declaration screen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ repositories {
 
 dependencies {
 
-	implementation 'uk.gov.laa.ccms.data:data-api:0.0.12'
+	implementation 'uk.gov.laa.ccms.data:data-api:0.0.14'
 
 	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.27'
 

--- a/src/main/java/uk/gov/laa/ccms/caab/bean/SummarySubmissionFormData.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/SummarySubmissionFormData.java
@@ -1,0 +1,21 @@
+package uk.gov.laa.ccms.caab.bean;
+
+import java.util.List;
+import lombok.Data;
+import uk.gov.laa.ccms.caab.bean.declaration.DynamicCheckbox;
+
+/**
+ * Represents the form data for a summary submission.
+ * Contains a list of dynamic checkbox options for declarations.
+ */
+@Data
+public class SummarySubmissionFormData {
+
+
+  /**
+   * A map of dynamic options for declarations.
+   * The key is the option name and the value is the DynamicCheckbox object.
+   */
+  private List<DynamicCheckbox> declarationOptions;
+
+}

--- a/src/main/java/uk/gov/laa/ccms/caab/bean/declaration/DynamicCheckbox.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/declaration/DynamicCheckbox.java
@@ -1,0 +1,22 @@
+package uk.gov.laa.ccms.caab.bean.declaration;
+
+import lombok.Data;
+
+/**
+ * Represents a dynamic option for declaration form data.
+ * This is typically used for rendering selectable options such as checkboxes.
+ */
+@Data
+public class DynamicCheckbox {
+
+  /**
+   * The identifier of the declaration field.
+   */
+  private boolean checked;
+
+  /**
+   * The displayable checkbox label.
+   */
+  private String fieldValueDisplayValue;
+
+}

--- a/src/main/java/uk/gov/laa/ccms/caab/bean/validators/declaration/DeclarationSubmissionValidator.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/validators/declaration/DeclarationSubmissionValidator.java
@@ -1,0 +1,43 @@
+package uk.gov.laa.ccms.caab.bean.validators.declaration;
+
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import uk.gov.laa.ccms.caab.bean.SummarySubmissionFormData;
+import uk.gov.laa.ccms.caab.bean.declaration.DynamicCheckbox;
+import uk.gov.laa.ccms.caab.bean.proceeding.ProceedingFormDataProceedingDetails;
+import uk.gov.laa.ccms.caab.bean.validators.AbstractValidator;
+
+/**
+ * Validator for the declaration details provided by summary submission form data.
+ */
+@Component
+public class DeclarationSubmissionValidator extends AbstractValidator {
+
+  @Override
+  public boolean supports(final Class<?> clazz) {
+    return SummarySubmissionFormData.class.isAssignableFrom(clazz);
+  }
+
+  /**
+   * Validates the  declaration details in the
+   * {@link uk.gov.laa.ccms.caab.bean.SummarySubmissionFormData}.
+   *
+   * @param target The object to be validated.
+   * @param errors The Errors object to store validation errors.
+   */
+  @Override
+  public void validate(final Object target, final Errors errors) {
+    final SummarySubmissionFormData summarySubmissionFormData =
+        (SummarySubmissionFormData) target;
+
+    // Check if any declarations were selected
+    if (summarySubmissionFormData.getDeclarationOptions() == null
+        || summarySubmissionFormData.getDeclarationOptions().stream().noneMatch(
+            DynamicCheckbox::isChecked)) {
+      errors.reject("declaration.required",
+          "You must read and acknowledge the Declaration(s) in order to proceed to submit.");
+    }
+
+  }
+
+}

--- a/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
@@ -15,6 +15,7 @@ import uk.gov.laa.ccms.data.model.CaseStatusLookupDetail;
 import uk.gov.laa.ccms.data.model.CategoryOfLawLookupDetail;
 import uk.gov.laa.ccms.data.model.ClientInvolvementTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
 import uk.gov.laa.ccms.data.model.EvidenceDocumentTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.LevelOfServiceLookupDetail;
 import uk.gov.laa.ccms.data.model.MatterTypeLookupDetail;
@@ -683,5 +684,36 @@ public class EbsApiClient {
         .onErrorResume(e -> ebsApiClientErrorHandler.handleApiRetrieveError(
             e, "Assessment summary attributes", queryParams));
   }
+
+
+  /**
+   * Retrieves declaration details based on the provided type and bill type.
+   * Constructs a query with the given parameters and sends a GET request to the API.
+   *
+   * @param type the type of declaration to retrieve
+   * @param billType the bill type to filter the declarations, may be null
+   * @return a Mono emitting the {@link DeclarationLookupDetail} or handling errors
+   */
+  public Mono<DeclarationLookupDetail> getDeclarations(
+      final String type,
+      final String billType) {
+    final MultiValueMap<String, String> queryParams = createDefaultQueryParams();
+    Optional.ofNullable(type)
+        .ifPresent(param -> queryParams.add("type", param));
+    Optional.ofNullable(billType)
+        .ifPresent(param -> queryParams.add("billType", param));
+
+    return ebsApiWebClient
+        .get()
+        .uri(builder -> builder.path("/lookup/declarations")
+            .queryParams(queryParams)
+            .build())
+        .retrieve()
+        .bodyToMono(DeclarationLookupDetail.class)
+        .onErrorResume(e -> ebsApiClientErrorHandler.handleApiRetrieveError(
+            e, "Declarations", queryParams));
+  }
+
+
 }
 

--- a/src/main/java/uk/gov/laa/ccms/caab/constants/ApplicationConstants.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/constants/ApplicationConstants.java
@@ -178,4 +178,14 @@ public class ApplicationConstants {
    */
   public static final String LINKED_CASES = "linkedCases";
 
+  /**
+   * Constant representing the declaration type for an application.
+   */
+  public static final String DECLARATION_APPLICATION = "APPLICATION";
+
+  /**
+   * Constant representing the declaration type for a bill.
+   */
+  public static final String DECLARATION_BILL = "BILL";
+
 }

--- a/src/main/java/uk/gov/laa/ccms/caab/mapper/SubmissionSummaryDisplayMapper.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/mapper/SubmissionSummaryDisplayMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
+import uk.gov.laa.ccms.caab.bean.declaration.DynamicCheckbox;
 import uk.gov.laa.ccms.caab.mapper.context.submission.GeneralDetailsSubmissionSummaryMappingContext;
 import uk.gov.laa.ccms.caab.mapper.context.submission.OpponentSubmissionSummaryMappingContext;
 import uk.gov.laa.ccms.caab.mapper.context.submission.ProceedingSubmissionSummaryMappingContext;
@@ -20,6 +21,8 @@ import uk.gov.laa.ccms.caab.model.summary.ProceedingAndCostSubmissionSummaryDisp
 import uk.gov.laa.ccms.caab.model.summary.ProceedingSubmissionSummaryDisplay;
 import uk.gov.laa.ccms.caab.model.summary.ProviderSubmissionSummaryDisplay;
 import uk.gov.laa.ccms.caab.model.summary.ScopeLimitationSubmissionSummaryDisplay;
+import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupValueDetail;
 
 /**
  * Mapper interface for converting submission summary details to display values.
@@ -213,6 +216,38 @@ public interface SubmissionSummaryDisplayMapper {
       @Context final OpponentSubmissionSummaryMappingContext context) {
     return COMMON_MAPPER.toDisplayValue(code, context.getCountry());
   }
+
+  /**
+   * Converts a {@link DeclarationLookupDetail} to a list of
+   * {@link uk.gov.laa.ccms.caab.bean.declaration.DynamicCheckbox}.
+   *
+   * @param declarationLookupDetail the detail object containing declaration data
+   * @return a list of {@link uk.gov.laa.ccms.caab.bean.declaration.DynamicCheckbox},
+   *         or null if the input is null
+   */
+  @Named("toDeclarationFormDataDynamicOptionList")
+  default List<DynamicCheckbox> toDeclarationFormDataDynamicOptionList(
+      DeclarationLookupDetail declarationLookupDetail) {
+    if (declarationLookupDetail == null) {
+      return null;
+    }
+
+    return declarationLookupDetail.getContent().stream()
+        .map(this::toDeclarationFormDataDynamicOption)
+        .toList();
+  }
+
+  /**
+   * Maps a {@link DeclarationLookupValueDetail} to a
+   * {@link uk.gov.laa.ccms.caab.bean.declaration.DynamicCheckbox}.
+   *
+   * @param declarationLookupValueDetail the value detail to map
+   * @return the mapped {@link uk.gov.laa.ccms.caab.bean.declaration.DynamicCheckbox}
+   */
+  @Mapping(target = "fieldValueDisplayValue", source = "text")
+  @Mapping(target = "checked", ignore = true)
+  DynamicCheckbox toDeclarationFormDataDynamicOption(
+      DeclarationLookupValueDetail declarationLookupValueDetail);
 
 
 }

--- a/src/main/java/uk/gov/laa/ccms/caab/service/LookupService.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/service/LookupService.java
@@ -39,6 +39,7 @@ import uk.gov.laa.ccms.data.model.CategoryOfLawLookupValueDetail;
 import uk.gov.laa.ccms.data.model.ClientInvolvementTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupValueDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
 import uk.gov.laa.ccms.data.model.LevelOfServiceLookupDetail;
 import uk.gov.laa.ccms.data.model.MatterTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.OutcomeResultLookupDetail;
@@ -508,6 +509,8 @@ public class LookupService {
         });
   }
 
+
+
   /**
    * Retrieves client summary list lookups.
    *
@@ -614,5 +617,17 @@ public class LookupService {
             .relationshipToClient(tuple.getT4())
             .build());
   }
+
+  /**
+   * Retrieves declaration details based only on the submission type.
+   *
+   * @param submissionType the type of submission for the declaration
+   * @return a Mono emitting the declaration lookup details
+   */
+  public Mono<DeclarationLookupDetail> getDeclarations(
+      final String submissionType) {
+    return ebsApiClient.getDeclarations(submissionType, null);
+  }
+
 
 }

--- a/src/main/resources/templates/application/sections/application-submit-declaration.html
+++ b/src/main/resources/templates/application/sections/application-submit-declaration.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en" th:replace="~{layout :: layout(title=~{::title},mainContent=~{::#main-content},pageCategory=${'cases'},breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>LAA CCMS - Start New Application</title>
+</head>
+<body>
+<div class="govuk-width-container">
+  <div id="breadcrumbs">
+    <a th:href="@{/application/summary}" class="govuk-back-link">Cancel and return application summary</a>
+  </div>
+  <div id="main-content">
+    <form action="#" th:action="@{/application/declaration}" th:object="${summarySubmissionFormData}" method="post">
+      <div th:replace="~{partials/error-summary :: error-summary}"></div>
+      <span class="govuk-caption-l">Application summary</span>
+      <h1 class="govuk-heading-l">
+        Sign Declaration
+      </h1>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <p class="govuk-body-l">
+            Please complete the declaration below by selecting the statements to confirm your agreement.
+          </p>
+        </div>
+      </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <span class="govuk-fieldset__heading">
+            Declarations
+          </span>
+              </legend>
+              <div class="govuk-checkboxes">
+                <div th:each="declarationOption, stat : *{declarationOptions}">
+                  <div class="govuk-checkboxes__item">
+                    <input class="govuk-checkboxes__input"
+                           th:id="'declaration_' + ${stat.index}"
+                           th:name="'declarationOptions[' + ${stat.index} + '].checked'"
+                           type="checkbox"
+                           th:checked="${declarationOption.checked}" />
+                    <label class="govuk-label govuk-checkboxes__label"
+                           th:for="'declaration_' + ${stat.index}">
+                      <span th:text="${declarationOption.fieldValueDisplayValue}"></span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+      <button class="govuk-button" data-module="govuk-button">
+        Continue
+      </button>
+    </form>
+  </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/application/sections/application-summary-complete.html
+++ b/src/main/resources/templates/application/sections/application-summary-complete.html
@@ -9,209 +9,211 @@
     <a th:href="@{/application/sections}" class="govuk-back-link">Return to create application</a>
   </div>
   <div id="main-content">
-    <span class="govuk-caption-l">Create application</span>
-    <h1 class="govuk-heading-l">
-      Application summary
-    </h1>
-    <p class="govuk-body-l">
-      The information you have entered in your Application is listed below. In order to print the overview please click on the 'Print this page' button.
-    </p>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <div class="moj-page-header-actions">
-          <div class="moj-page-header-actions__title">
-            <h2 class="govuk-heading-m">Client details</h2>
-          </div>
-          <div class="moj-page-header-actions__actions">
-            <div class="moj-button-menu">
-              <div class="moj-button-menu__wrapper">
-                <a class="govuk-button moj-button-menu__item govuk-button--secondary moj-page-header-actions__action" th:href="@{/application/summary/print}" data-module="govuk-button" target="_blank">
-                  Print this page
-                </a>
+    <form action="#" th:action="@{/application/summary}" th:object="${summarySubmissionFormData}" method="post">
+      <span class="govuk-caption-l">Create application</span>
+      <h1 class="govuk-heading-l">
+        Application summary
+      </h1>
+      <p class="govuk-body-l">
+        The information you have entered in your Application is listed below. In order to print the overview please click on the 'Print this page' button.
+      </p>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <div class="moj-page-header-actions">
+            <div class="moj-page-header-actions__title">
+              <h2 class="govuk-heading-m">Client details</h2>
+            </div>
+            <div class="moj-page-header-actions__actions">
+              <div class="moj-button-menu">
+                <div class="moj-button-menu__wrapper">
+                  <a class="govuk-button moj-button-menu__item govuk-button--secondary moj-page-header-actions__action" th:href="@{/application/summary/print}" data-module="govuk-button" target="_blank">
+                    Print this page
+                  </a>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <h3 class="govuk-heading-s">Basic client details</h3>
-        <dl class="govuk-summary-list">
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Title', ${submissionSummary.clientLookups.contactTitle.description})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Surname', ${submissionSummary.client.basicDetails.surname})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Middle name(s)', ${submissionSummary.client.basicDetails.middleNames})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('First name', ${submissionSummary.client.basicDetails.firstName})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Surname at birth', ${submissionSummary.client.basicDetails.surnameAtBirth})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Date of Birth', ${submissionSummary.client.basicDetails.dobDay + '/' + submissionSummary.client.basicDetails.dobMonth + '/' + submissionSummary.client.basicDetails.dobYear})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Country of Origin', ${submissionSummary.clientLookups.countryOfOrigin.description})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('NI Number', ${submissionSummary.client.basicDetails.nationalInsuranceNumber})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Home Office Number', ${submissionSummary.client.basicDetails.homeOfficeNumber})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Gender', ${submissionSummary.clientLookups.gender.description})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Marital status', ${submissionSummary.clientLookups.maritalStatus.description})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplayYesNo('High profile client', ${submissionSummary.client.basicDetails.highProfileClient})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplayYesNo('Vulnerable client', ${submissionSummary.client.basicDetails.vulnerableClient})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplayYesNo('Mental incapacity', ${submissionSummary.client.basicDetails.mentalIncapacity})}"></div>
-        </dl>
-        <h3 class="govuk-heading-s">Client contact details</h3>
-        <dl class="govuk-summary-list">
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Telephone - Home', ${submissionSummary.client.contactDetails.telephoneHome})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Telephone Work', ${submissionSummary.client.contactDetails.telephoneWork})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Mobile', ${submissionSummary.client.contactDetails.telephoneMobile})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('E-mail Address', ${submissionSummary.client.contactDetails.emailAddress})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Correspondence Method', ${submissionSummary.clientLookups.correspondenceMethod.description})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Correspondence Language', ${submissionSummary.clientLookups.correspondenceLanguage.description})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Password Reminder', ${submissionSummary.client.contactDetails.passwordReminder})}"></div>
-        </dl>
-        <h3 class="govuk-heading-s">Client address details</h3>
-        <dl class="govuk-summary-list">
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Country', ${submissionSummary.clientLookups.country.description})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('House Name / Number', ${submissionSummary.client.addressDetails.houseNameNumber})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Post Code', ${submissionSummary.client.addressDetails.postcode})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 1', ${submissionSummary.client.addressDetails.addressLine1})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 2', ${submissionSummary.client.addressDetails.addressLine2})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('City / Town', ${submissionSummary.client.addressDetails.cityTown})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('County', ${submissionSummary.client.addressDetails.county})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('No Fixed Abode', ${submissionSummary.client.addressDetails.noFixedAbode})}"></div>
-        </dl>
-        <h3 class="govuk-heading-s">Equal opportunities monitoring</h3>
-        <dl class="govuk-summary-list">
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Ethnic Origin', ${submissionSummary.clientLookups.ethnicity.description})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Disability', ${submissionSummary.clientLookups.disability.description})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Special Considerations', ${submissionSummary.client.monitoringDetails.specialConsiderations})}"></div>
-        </dl>
-      </div>
-    </div>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m">General details</h2>
-        <dl class="govuk-summary-list">
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Category of Law', ${submissionSummary.generalDetails.categoryOfLaw})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Application Type', ${submissionSummary.generalDetails.applicationType})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Delegated Functions Date', ${#dates.format(submissionSummary.generalDetails.delegatedFunctionsDate, 'dd/MM/yyyy')})}"></div>
-        </dl>
-        <h3 class="govuk-heading-s">Correspondence address</h3>
-        <dl class="govuk-summary-list">
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Preferred Address', ${submissionSummary.generalDetails.preferredAddress})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Country', ${submissionSummary.generalDetails.country})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('House Name / Number', ${submissionSummary.generalDetails.houseNameOrNumber})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Post Code', ${submissionSummary.generalDetails.postcode})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('C/O', ${submissionSummary.generalDetails.careOf})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 1', ${submissionSummary.generalDetails.addressLine1})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 2', ${submissionSummary.generalDetails.addressLine2})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('City / Town', ${submissionSummary.generalDetails.city})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('County', ${submissionSummary.generalDetails.county})}"></div>
-        </dl>
-      </div>
-    </div>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m">Provider details</h2>
-        <dl class="govuk-summary-list">
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Office', ${submissionSummary.providerDetails.office})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Name of solicitor or Fellow of the Institute of Legal Executives instructed', ${submissionSummary.providerDetails.feeEarner})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Supervisor', ${submissionSummary.providerDetails.supervisor})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Provider Case Reference', ${submissionSummary.providerDetails.providerCaseReference})}"></div>
-          <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Contact Name', ${submissionSummary.providerDetails.contactName})}"></div>
-        </dl>
-      </div>
-    </div>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m">Proceedings and costs</h2>
-        <div th:each="proceeding, proceedingStat : ${submissionSummary.proceedingsAndCosts.proceedings}">
-          <h3 class="govuk-heading-s">Proceeding [[${proceedingStat.index + 1}]]</h3>
+          <h3 class="govuk-heading-s">Basic client details</h3>
           <dl class="govuk-summary-list">
-            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Matter Type', ${proceeding.matterType})}"></div>
-            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Proceeding', ${proceeding.proceeding})}"></div>
-            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Client Involvement Type', ${proceeding.clientInvolvementType})}"></div>
-            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Form of Civil Legal Service', ${proceeding.formOfCivilLegalService})}"></div>
-            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Type of Order', ${proceeding.typeOfOrder})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Title', ${submissionSummary.clientLookups.contactTitle.description})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Surname', ${submissionSummary.client.basicDetails.surname})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Middle name(s)', ${submissionSummary.client.basicDetails.middleNames})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('First name', ${submissionSummary.client.basicDetails.firstName})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Surname at birth', ${submissionSummary.client.basicDetails.surnameAtBirth})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Date of Birth', ${submissionSummary.client.basicDetails.dobDay + '/' + submissionSummary.client.basicDetails.dobMonth + '/' + submissionSummary.client.basicDetails.dobYear})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Country of Origin', ${submissionSummary.clientLookups.countryOfOrigin.description})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('NI Number', ${submissionSummary.client.basicDetails.nationalInsuranceNumber})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Home Office Number', ${submissionSummary.client.basicDetails.homeOfficeNumber})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Gender', ${submissionSummary.clientLookups.gender.description})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Marital status', ${submissionSummary.clientLookups.maritalStatus.description})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplayYesNo('High profile client', ${submissionSummary.client.basicDetails.highProfileClient})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplayYesNo('Vulnerable client', ${submissionSummary.client.basicDetails.vulnerableClient})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplayYesNo('Mental incapacity', ${submissionSummary.client.basicDetails.mentalIncapacity})}"></div>
           </dl>
-          <div th:each="scopeLimitation, scopeLimitationStat : ${proceeding.scopeLimitations}">
-            <h4 class="govuk-heading-s">Scope Limitation [[${scopeLimitationStat.index + 1}]]</h4>
-            <dl class="govuk-summary-list">
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Scope Limitation', ${scopeLimitation.scopeLimitation})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Scope Limitation Wording', ${scopeLimitation.scopeLimitationWording})}"></div>
-            </dl>
-          </div>
+          <h3 class="govuk-heading-s">Client contact details</h3>
           <dl class="govuk-summary-list">
-            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Case Cost Limitation', ${#numbers.formatCurrency(submissionSummary.proceedingsAndCosts.caseCostLimitation)})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Telephone - Home', ${submissionSummary.client.contactDetails.telephoneHome})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Telephone Work', ${submissionSummary.client.contactDetails.telephoneWork})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Mobile', ${submissionSummary.client.contactDetails.telephoneMobile})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('E-mail Address', ${submissionSummary.client.contactDetails.emailAddress})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Correspondence Method', ${submissionSummary.clientLookups.correspondenceMethod.description})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Correspondence Language', ${submissionSummary.clientLookups.correspondenceLanguage.description})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Password Reminder', ${submissionSummary.client.contactDetails.passwordReminder})}"></div>
+          </dl>
+          <h3 class="govuk-heading-s">Client address details</h3>
+          <dl class="govuk-summary-list">
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Country', ${submissionSummary.clientLookups.country.description})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('House Name / Number', ${submissionSummary.client.addressDetails.houseNameNumber})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Post Code', ${submissionSummary.client.addressDetails.postcode})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 1', ${submissionSummary.client.addressDetails.addressLine1})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 2', ${submissionSummary.client.addressDetails.addressLine2})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('City / Town', ${submissionSummary.client.addressDetails.cityTown})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('County', ${submissionSummary.client.addressDetails.county})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('No Fixed Abode', ${submissionSummary.client.addressDetails.noFixedAbode})}"></div>
+          </dl>
+          <h3 class="govuk-heading-s">Equal opportunities monitoring</h3>
+          <dl class="govuk-summary-list">
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Ethnic Origin', ${submissionSummary.clientLookups.ethnicity.description})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Disability', ${submissionSummary.clientLookups.disability.description})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Special Considerations', ${submissionSummary.client.monitoringDetails.specialConsiderations})}"></div>
           </dl>
         </div>
       </div>
-    </div>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m">Opponents and other parties</h2>
-        <div th:each="opponent : ${submissionSummary.opponentsAndOtherParties.opponents}">
-          <h3 class="govuk-heading-s" th:text="${opponent.type}"></h3>
-          <div th:if="${opponent.type == 'Individual'}">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m">General details</h2>
+          <dl class="govuk-summary-list">
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Category of Law', ${submissionSummary.generalDetails.categoryOfLaw})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Application Type', ${submissionSummary.generalDetails.applicationType})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Delegated Functions Date', ${#dates.format(submissionSummary.generalDetails.delegatedFunctionsDate, 'dd/MM/yyyy')})}"></div>
+          </dl>
+          <h3 class="govuk-heading-s">Correspondence address</h3>
+          <dl class="govuk-summary-list">
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Preferred Address', ${submissionSummary.generalDetails.preferredAddress})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Country', ${submissionSummary.generalDetails.country})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('House Name / Number', ${submissionSummary.generalDetails.houseNameOrNumber})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Post Code', ${submissionSummary.generalDetails.postcode})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('C/O', ${submissionSummary.generalDetails.careOf})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 1', ${submissionSummary.generalDetails.addressLine1})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 2', ${submissionSummary.generalDetails.addressLine2})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('City / Town', ${submissionSummary.generalDetails.city})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('County', ${submissionSummary.generalDetails.county})}"></div>
+          </dl>
+        </div>
+      </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m">Provider details</h2>
+          <dl class="govuk-summary-list">
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Office', ${submissionSummary.providerDetails.office})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Name of solicitor or Fellow of the Institute of Legal Executives instructed', ${submissionSummary.providerDetails.feeEarner})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Supervisor', ${submissionSummary.providerDetails.supervisor})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Provider Case Reference', ${submissionSummary.providerDetails.providerCaseReference})}"></div>
+            <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Contact Name', ${submissionSummary.providerDetails.contactName})}"></div>
+          </dl>
+        </div>
+      </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m">Proceedings and costs</h2>
+          <div th:each="proceeding, proceedingStat : ${submissionSummary.proceedingsAndCosts.proceedings}">
+            <h3 class="govuk-heading-s">Proceeding [[${proceedingStat.index + 1}]]</h3>
             <dl class="govuk-summary-list">
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Title', ${opponent.title})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Surname', ${opponent.surname})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('First Name', ${opponent.firstName})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Middle Name(s)', ${opponent.middleNames})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Date of Birth', ${opponent.dateOfBirth})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Relationship to Case', ${opponent.relationshipToCase})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Relationship to Client', ${opponent.relationshipToClient})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('National Insurance Number', ${opponent.nationalInsuranceNumber})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('House Name / Number', ${opponent.houseNameOrNumber})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 1', ${opponent.addressLine1})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 2', ${opponent.addressLine2})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('City / Town', ${opponent.city})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('County', ${opponent.county})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Country', ${opponent.country})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Post Code', ${opponent.postcode})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Telephone - Home', ${opponent.telephoneHome})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Telephone - Work', ${opponent.telephoneWork})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Telephone - Mobile', ${opponent.telephoneMobile})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Fax No.', ${opponent.faxNumber})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Email Address', ${opponent.emailAddress})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Party is Legal Aided?', ${opponent.legalAided})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Certificate Number', ${opponent.certificateNumber})}"></div>
+              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Matter Type', ${proceeding.matterType})}"></div>
+              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Proceeding', ${proceeding.proceeding})}"></div>
+              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Client Involvement Type', ${proceeding.clientInvolvementType})}"></div>
+              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Form of Civil Legal Service', ${proceeding.formOfCivilLegalService})}"></div>
+              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Type of Order', ${proceeding.typeOfOrder})}"></div>
             </dl>
-          </div>
-          <div th:if="${opponent.type == 'Organisation'}">
+            <div th:each="scopeLimitation, scopeLimitationStat : ${proceeding.scopeLimitations}">
+              <h4 class="govuk-heading-s">Scope Limitation [[${scopeLimitationStat.index + 1}]]</h4>
+              <dl class="govuk-summary-list">
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Scope Limitation', ${scopeLimitation.scopeLimitation})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Scope Limitation Wording', ${scopeLimitation.scopeLimitationWording})}"></div>
+              </dl>
+            </div>
             <dl class="govuk-summary-list">
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Organisation Name', ${opponent.organisationName})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Organisation Type', ${opponent.organisationType})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Currently Trading', ${opponent.currentlyTrading})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Relationship to Case', ${opponent.relationshipToCase})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Relationship to Client', ${opponent.relationshipToClient})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Contact Name and Role', ${opponent.contactNameRole})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Building Name / Number', ${opponent.houseNameOrNumber})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 1', ${opponent.addressLine1})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 2', ${opponent.addressLine2})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('City / Town', ${opponent.city})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('County', ${opponent.county})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Country', ${opponent.country})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Post Code', ${opponent.postcode})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Telephone', ${opponent.telephoneHome})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Fax', ${opponent.faxNumber})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Email Address', ${opponent.emailAddress})}"></div>
-              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Any other information about the Liable Organisation', ${opponent.otherInformation})}"></div>
+              <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Case Cost Limitation', ${#numbers.formatCurrency(submissionSummary.proceedingsAndCosts.caseCostLimitation)})}"></div>
             </dl>
           </div>
         </div>
       </div>
-    </div>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m">Means assessment</h2>
-        <div th:insert="application/partials/summary-fragments :: assessmentSummaryFragment(summary=${submissionSummary.meansAssessment}, isSinglePageSummary=${false})"></div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m">Opponents and other parties</h2>
+          <div th:each="opponent : ${submissionSummary.opponentsAndOtherParties.opponents}">
+            <h3 class="govuk-heading-s" th:text="${opponent.type}"></h3>
+            <div th:if="${opponent.type == 'Individual'}">
+              <dl class="govuk-summary-list">
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Title', ${opponent.title})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Surname', ${opponent.surname})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('First Name', ${opponent.firstName})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Middle Name(s)', ${opponent.middleNames})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Date of Birth', ${opponent.dateOfBirth})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Relationship to Case', ${opponent.relationshipToCase})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Relationship to Client', ${opponent.relationshipToClient})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('National Insurance Number', ${opponent.nationalInsuranceNumber})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('House Name / Number', ${opponent.houseNameOrNumber})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 1', ${opponent.addressLine1})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 2', ${opponent.addressLine2})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('City / Town', ${opponent.city})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('County', ${opponent.county})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Country', ${opponent.country})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Post Code', ${opponent.postcode})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Telephone - Home', ${opponent.telephoneHome})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Telephone - Work', ${opponent.telephoneWork})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Telephone - Mobile', ${opponent.telephoneMobile})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Fax No.', ${opponent.faxNumber})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Email Address', ${opponent.emailAddress})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Party is Legal Aided?', ${opponent.legalAided})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Certificate Number', ${opponent.certificateNumber})}"></div>
+              </dl>
+            </div>
+            <div th:if="${opponent.type == 'Organisation'}">
+              <dl class="govuk-summary-list">
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Organisation Name', ${opponent.organisationName})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Organisation Type', ${opponent.organisationType})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Currently Trading', ${opponent.currentlyTrading})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Relationship to Case', ${opponent.relationshipToCase})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Relationship to Client', ${opponent.relationshipToClient})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Contact Name and Role', ${opponent.contactNameRole})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Building Name / Number', ${opponent.houseNameOrNumber})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 1', ${opponent.addressLine1})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Address Line 2', ${opponent.addressLine2})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('City / Town', ${opponent.city})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('County', ${opponent.county})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Country', ${opponent.country})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Post Code', ${opponent.postcode})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Telephone', ${opponent.telephoneHome})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Fax', ${opponent.faxNumber})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Email Address', ${opponent.emailAddress})}"></div>
+                <div th:replace="~{application/partials/summary-fragments :: summaryListDisplay('Any other information about the Liable Organisation', ${opponent.otherInformation})}"></div>
+              </dl>
+            </div>
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m">Merits assessment</h2>
-        <div th:insert="application/partials/summary-fragments :: assessmentSummaryFragment(summary=${submissionSummary.meritsAssessment}, isSinglePageSummary=${false})"></div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m">Means assessment</h2>
+          <div th:insert="application/partials/summary-fragments :: assessmentSummaryFragment(summary=${submissionSummary.meansAssessment}, isSinglePageSummary=${false})"></div>
+        </div>
       </div>
-    </div>
-    <div class="govuk-button-group">
-      <button type="submit" class="govuk-button" data-module="govuk-button">
-        Confirm
-      </button>
-      <a class="govuk-button govuk-button--secondary" data-module="govuk-button" th:href="@{/application/summary/print}" target="_blank">
-        Print this page
-      </a>
-    </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m">Merits assessment</h2>
+          <div th:insert="application/partials/summary-fragments :: assessmentSummaryFragment(summary=${submissionSummary.meritsAssessment}, isSinglePageSummary=${false})"></div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        <button type="submit" class="govuk-button" data-module="govuk-button">
+          Confirm
+        </button>
+        <a class="govuk-button govuk-button--secondary" data-module="govuk-button" th:href="@{/application/summary/print}" target="_blank">
+          Print this page
+        </a>
+      </div>
+    </form>
   </div>
 </div>
 </body>

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/validators/declaration/DeclarationSubmissionValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/validators/declaration/DeclarationSubmissionValidatorTest.java
@@ -1,0 +1,81 @@
+package uk.gov.laa.ccms.caab.bean.validators.declaration;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import uk.gov.laa.ccms.caab.bean.SummarySubmissionFormData;
+import uk.gov.laa.ccms.caab.bean.declaration.DynamicCheckbox;
+
+
+@ExtendWith(SpringExtension.class)
+class DeclarationSubmissionValidatorTest {
+
+  @InjectMocks
+  private DeclarationSubmissionValidator declarationSubmissionValidator;
+
+  private SummarySubmissionFormData summarySubmissionFormData;
+
+  private Errors errors;
+
+  @BeforeEach
+  public void setUp() {
+    summarySubmissionFormData = new SummarySubmissionFormData();
+    errors = new BeanPropertyBindingResult(summarySubmissionFormData, "summarySubmissionFormData");
+  }
+
+  @Test
+  public void supports_ReturnsTrueForSummarySubmissionFormDataClass() {
+    assertTrue(declarationSubmissionValidator.supports(SummarySubmissionFormData.class));
+  }
+
+  @Test
+  public void supports_ReturnsFalseForOtherClasses() {
+    assertFalse(declarationSubmissionValidator.supports(Object.class));
+  }
+
+  @Test
+  public void validate_WithNullDeclarationOptions_HasErrors() {
+    summarySubmissionFormData.setDeclarationOptions(null);
+    declarationSubmissionValidator.validate(summarySubmissionFormData, errors);
+
+    assertTrue(errors.hasErrors());
+    assertNotNull(errors.getGlobalError());
+    assertEquals("declaration.required", errors.getGlobalError().getCode());
+  }
+
+  @Test
+  public void validate_WithUncheckedDeclarationOptions_HasErrors() {
+    final DynamicCheckbox uncheckedCheckbox = new DynamicCheckbox();
+    uncheckedCheckbox.setChecked(false);
+    summarySubmissionFormData.setDeclarationOptions(List.of(uncheckedCheckbox));
+
+    declarationSubmissionValidator.validate(summarySubmissionFormData, errors);
+
+    assertTrue(errors.hasErrors());
+    assertNotNull(errors.getGlobalError());
+    assertEquals("declaration.required", errors.getGlobalError().getCode());
+  }
+
+  @Test
+  public void validate_WithCheckedDeclarationOptions_NoErrors() {
+    final DynamicCheckbox checkedCheckbox = new DynamicCheckbox();
+    checkedCheckbox.setChecked(true);
+    summarySubmissionFormData.setDeclarationOptions(List.of(checkedCheckbox));
+
+    declarationSubmissionValidator.validate(summarySubmissionFormData, errors);
+
+    assertFalse(errors.hasErrors());
+  }
+
+}

--- a/src/test/java/uk/gov/laa/ccms/caab/mapper/SubmissionSummaryDisplayMapperTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/mapper/SubmissionSummaryDisplayMapperTest.java
@@ -1,6 +1,7 @@
 package uk.gov.laa.ccms.caab.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.laa.ccms.caab.bean.declaration.DynamicCheckbox;
 import uk.gov.laa.ccms.caab.mapper.context.submission.GeneralDetailsSubmissionSummaryMappingContext;
 import uk.gov.laa.ccms.caab.mapper.context.submission.OpponentSubmissionSummaryMappingContext;
 import uk.gov.laa.ccms.caab.mapper.context.submission.ProceedingSubmissionSummaryMappingContext;
@@ -36,6 +38,8 @@ import uk.gov.laa.ccms.caab.model.summary.ProviderSubmissionSummaryDisplay;
 import uk.gov.laa.ccms.caab.model.summary.ScopeLimitationSubmissionSummaryDisplay;
 import uk.gov.laa.ccms.data.model.CommonLookupDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupValueDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupValueDetail;
 
 @ExtendWith(SpringExtension.class)
 class SubmissionSummaryDisplayMapperTest {
@@ -447,5 +451,43 @@ class SubmissionSummaryDisplayMapperTest {
         .country(countryLookup)
         .build();
   }
+
+  @Test
+  @DisplayName("toDeclarationFormDataDynamicOptionList should return null when DeclarationLookupDetail is null")
+  void toDeclarationFormDataDynamicOptionList_nullDeclarationLookupDetail_returnsNull() {
+    final List<DynamicCheckbox> result = mapper.toDeclarationFormDataDynamicOptionList(null);
+    assertNull(result, "Expected result to be null when DeclarationLookupDetail is null.");
+  }
+
+  @Test
+  @DisplayName("toDeclarationFormDataDynamicOptionList should correctly map content when DeclarationLookupDetail is valid")
+  void toDeclarationFormDataDynamicOptionList_validDeclarationLookupDetail_returnsMappedDynamicOptionList() {
+    final DeclarationLookupValueDetail declarationValueDetail = new DeclarationLookupValueDetail();
+    declarationValueDetail.setText("Checkbox Option 1");
+
+    final DeclarationLookupDetail declarationLookupDetail = new DeclarationLookupDetail();
+    declarationLookupDetail.setContent(List.of(declarationValueDetail));
+
+    final List<DynamicCheckbox> result = mapper.toDeclarationFormDataDynamicOptionList(declarationLookupDetail);
+
+    assertNotNull(result, "Result should not be null.");
+    assertEquals(1, result.size(), "Result list should have correct size.");
+    assertEquals("Checkbox Option 1", result.get(0).getFieldValueDisplayValue(), "Field value display should be mapped correctly.");
+    assertFalse(result.get(0).isChecked(), "Checked should be false by default.");
+  }
+
+  @Test
+  @DisplayName("toDeclarationFormDataDynamicOption should correctly map fields when DeclarationLookupValueDetail is valid")
+  void toDeclarationFormDataDynamicOption_validDeclarationLookupValueDetail_returnsMappedDynamicCheckbox() {
+    final DeclarationLookupValueDetail declarationValueDetail = new DeclarationLookupValueDetail();
+    declarationValueDetail.setText("Checkbox Option 1");
+
+    final DynamicCheckbox result = mapper.toDeclarationFormDataDynamicOption(declarationValueDetail);
+
+    assertNotNull(result, "Result should not be null.");
+    assertEquals("Checkbox Option 1", result.getFieldValueDisplayValue(), "Field value display should be mapped correctly.");
+    assertFalse(result.isChecked(), "Checked should be false by default.");
+  }
+
 
 }

--- a/src/test/java/uk/gov/laa/ccms/caab/service/LookupServiceTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/service/LookupServiceTest.java
@@ -49,6 +49,7 @@ import uk.gov.laa.ccms.data.model.CategoryOfLawLookupValueDetail;
 import uk.gov.laa.ccms.data.model.ClientInvolvementTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupValueDetail;
+import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
 import uk.gov.laa.ccms.data.model.LevelOfServiceLookupDetail;
 import uk.gov.laa.ccms.data.model.MatterTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.OutcomeResultLookupDetail;
@@ -735,6 +736,24 @@ public class LookupServiceTest {
         )
         .verifyComplete();
   }
+
+  @Test
+  @DisplayName("getDeclarations with submissionType returns data successfully")
+  void getDeclarations_success() {
+    final String submissionType = "SUB_TYPE";
+    final DeclarationLookupDetail mockDeclarationDetail = new DeclarationLookupDetail();
+
+    when(ebsApiClient.getDeclarations(submissionType, null)).thenReturn(Mono.just(mockDeclarationDetail));
+
+    final Mono<DeclarationLookupDetail> result = lookupService.getDeclarations(submissionType);
+
+    StepVerifier.create(result)
+        .expectNext(mockDeclarationDetail)
+        .verifyComplete();
+
+    verify(ebsApiClient).getDeclarations(submissionType, null);
+  }
+
 
 
 


### PR DESCRIPTION
This task involves creating a submission declaration screen in the CAAB-UI. The screen will require the user to confirm that they have obtained the necessary signed declarations/signatures and will retain them upon the client's file. The user cannot proceed to the submission until this declaration is acknowledged. Clicking "Back" will return the user to the confirmation summary screen, while clicking "Continue" after signing the declaration will navigate the user to the submission in progress screen.

As a user, 
I want to sign a declaration before submitting my application, 
so that I can confirm my agreement and proceed with the submission.