### PR TITLE
Update assessment-api version to 0.0.16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
 	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.31'
 
-	implementation 'uk.gov.laa.ccms.caab:assessment-api:0.0.14'
+	implementation 'uk.gov.laa.ccms.caab:assessment-api:0.0.16'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update assessment-api version to 0.0.16