### PR TITLE
Update caab-api version to 0.0.35

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
 	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.27'
 
-	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.31'
+	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.35'
 
 	implementation 'uk.gov.laa.ccms.caab:assessment-api:0.0.14'
 


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update caab-api version to 0.0.35