### PR TITLE
Fix: Downgrade Github Runner

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -35,7 +35,7 @@ jobs:
 
   build-test:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The build pipeline currently fails because an upgraded version Python restricts package installation on externally managed environments (github runner). This stops the localstack setup step from running.

See https://github.com/localstack/setup-localstack/issues/42, https://github.com/actions/runner-images/issues/10636.

Downgrade Github Runner image until this is fixed.
