### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4.1.7 in /.github/workflows"

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v3
       # Assume role in cloud platform
       - name: download jar
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v3
         with:
           name: caab-jar
 


### PR DESCRIPTION
Reverts ministryofjustice/laa-ccms-caab#262