### PR TITLE
CCMSPUI-376: Migrate notification summary from SOA-API to EBS-API

### DIFF
--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/SoaApiClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/SoaApiClientIntegrationTest.java
@@ -85,26 +85,6 @@ public class SoaApiClientIntegrationTest extends AbstractIntegrationTest {
   }
 
   @Test
-  public void testGetNotificationsSummary_returnData() throws Exception {
-    String loginId = USER_1;
-    String userType = USER_TYPE;
-    NotificationSummary expectedSummary = buildNotificationSummary();
-    String summaryJson = objectMapper.writeValueAsString(expectedSummary);
-
-    wiremock.stubFor(get(String.format("/users/%s/notifications/summary", loginId))
-        .withHeader(SOA_GATEWAY_USER_LOGIN_ID, equalTo(loginId))
-        .withHeader(SOA_GATEWAY_USER_ROLE, equalTo(userType))
-        .willReturn(okJson(summaryJson)));
-
-    Mono<NotificationSummary> summaryMono =
-        soaApiClient.getNotificationsSummary(loginId, userType);
-
-    NotificationSummary summary = summaryMono.block();
-
-    assertEquals(summaryJson, objectMapper.writeValueAsString(summary));
-  }
-
-  @Test
   public void testGetCases_returnData() throws Exception {
     String loginId = USER_1;
     String userType = USER_TYPE;

--- a/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
@@ -1,6 +1,5 @@
 package uk.gov.laa.ccms.caab.client;
 
-import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +31,7 @@ import uk.gov.laa.ccms.data.model.ScopeLimitationDetails;
 import uk.gov.laa.ccms.data.model.StageEndLookupDetail;
 import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.data.model.UserDetails;
+import uk.gov.laa.ccms.soa.gateway.model.NotificationSummary;
 
 /**
  * Client class responsible for interacting with the ebs-api microservice to retrieve various data
@@ -66,6 +66,16 @@ public class EbsApiClient {
             .bodyToMono(UserDetail.class)
             .onErrorResume(e -> ebsApiClientErrorHandler.handleApiRetrieveError(
                 e, "User", "login id", loginId));
+  }
+
+  public Mono<NotificationSummary> getUserNotificationSummary(final String loginId) {
+    return ebsApiWebClient
+        .get()
+        .uri("/users/{loginId}/notifications/summary", loginId)
+        .retrieve()
+        .bodyToMono(NotificationSummary.class)
+        .onErrorResume(e -> ebsApiClientErrorHandler.handleApiRetrieveError(
+            e, "User", "login id", loginId));
   }
 
   /**

--- a/src/main/java/uk/gov/laa/ccms/caab/client/SoaApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/SoaApiClient.java
@@ -28,7 +28,6 @@ import uk.gov.laa.ccms.soa.gateway.model.ClientTransactionResponse;
 import uk.gov.laa.ccms.soa.gateway.model.ContractDetails;
 import uk.gov.laa.ccms.soa.gateway.model.CoverSheet;
 import uk.gov.laa.ccms.soa.gateway.model.Document;
-import uk.gov.laa.ccms.soa.gateway.model.NotificationSummary;
 import uk.gov.laa.ccms.soa.gateway.model.Notifications;
 import uk.gov.laa.ccms.soa.gateway.model.OrganisationDetail;
 import uk.gov.laa.ccms.soa.gateway.model.OrganisationDetails;
@@ -52,28 +51,6 @@ public class SoaApiClient {
   private final WebClient soaApiWebClient;
 
   private final SoaApiClientErrorHandler soaApiClientErrorHandler;
-
-  /**
-   * Retrieve the summary of notifications for a given user.
-   *
-   * @param loginId  The login identifier for the user.
-   * @param userType Type of the user (e.g., admin, user).
-   * @return A Mono wrapping the NotificationSummary for the specified user.
-   */
-  public Mono<NotificationSummary> getNotificationsSummary(
-      final String loginId,
-      final String userType) {
-
-    return soaApiWebClient
-        .get()
-        .uri("/users/{loginId}/notifications/summary", loginId)
-        .header(SOA_GATEWAY_USER_LOGIN_ID, loginId)
-        .header(SOA_GATEWAY_USER_ROLE, userType)
-        .retrieve()
-        .bodyToMono(NotificationSummary.class)
-        .onErrorResume(e -> soaApiClientErrorHandler.handleApiRetrieveError(
-            e, "Notification summary", "user login id", loginId));
-  }
 
   /**
    * Fetches the contract details for the given criteria.

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/HomeController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/HomeController.java
@@ -36,7 +36,7 @@ public class HomeController {
 
     // Retrieve a summary of the User's Notifications & Actions from the SOA Gateway
     NotificationSummary notificationSummary = notificationService.getNotificationsSummary(
-            user.getLoginId(), user.getUserType()).block();
+        user.getLoginId()).block();
 
     boolean showNotifications = notificationSummary != null;
     model.addAttribute("showNotifications", showNotifications);

--- a/src/main/java/uk/gov/laa/ccms/caab/service/NotificationService.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/service/NotificationService.java
@@ -15,6 +15,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import uk.gov.laa.ccms.caab.bean.NotificationSearchCriteria;
 import uk.gov.laa.ccms.caab.client.CaabApiClient;
+import uk.gov.laa.ccms.caab.client.EbsApiClient;
 import uk.gov.laa.ccms.caab.client.S3ApiClient;
 import uk.gov.laa.ccms.caab.client.SoaApiClient;
 import uk.gov.laa.ccms.caab.exception.CaabApplicationException;
@@ -36,6 +37,7 @@ import uk.gov.laa.ccms.soa.gateway.model.Notifications;
 @Slf4j
 public class NotificationService {
 
+  private final EbsApiClient ebsApiClient;
   private final SoaApiClient soaApiClient;
   private final CaabApiClient caabApiClient;
   private final S3ApiClient s3ApiClient;
@@ -48,11 +50,10 @@ public class NotificationService {
    * Retrieve the summary of notifications for a given user.
    *
    * @param loginId  The login identifier for the user.
-   * @param userType Type of the user (e.g., admin, user).
    * @return A Mono wrapping the NotificationSummary for the specified user.
    */
-  public Mono<NotificationSummary> getNotificationsSummary(String loginId, String userType) {
-    return soaApiClient.getNotificationsSummary(loginId, userType);
+  public Mono<NotificationSummary> getNotificationsSummary(String loginId) {
+    return ebsApiClient.getUserNotificationSummary(loginId);
   }
 
   /**

--- a/src/test/java/uk/gov/laa/ccms/caab/client/EbsApiClientTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/client/EbsApiClientTest.java
@@ -48,6 +48,7 @@ import uk.gov.laa.ccms.data.model.ScopeLimitationDetails;
 import uk.gov.laa.ccms.data.model.StageEndLookupDetail;
 import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.data.model.UserDetails;
+import uk.gov.laa.ccms.soa.gateway.model.NotificationSummary;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -68,8 +69,6 @@ public class EbsApiClientTest {
 
   @InjectMocks
   private EbsApiClient ebsApiClient;
-
-
 
   ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
 
@@ -111,6 +110,62 @@ public class EbsApiClientTest {
     final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(loginId);
 
     StepVerifier.create(userDetailsMono)
+        .verifyComplete();
+  }
+
+  @Test
+  void getUserNotificationSummary_returnsData() {
+    final String loginId = "user1";
+    final String expectedUri = "/users/{loginId}/notifications/summary";
+
+    final NotificationSummary mockNotificationSummary = new NotificationSummary();
+    mockNotificationSummary.setNotifications(1);
+    mockNotificationSummary.setStandardActions(3);
+    mockNotificationSummary.setOverdueActions(2);
+
+    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+    when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
+    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+    when(responseMock.bodyToMono(NotificationSummary.class)).thenReturn(
+        Mono.just(mockNotificationSummary));
+
+    final Mono<NotificationSummary> notificationSummary = ebsApiClient.getUserNotificationSummary(
+        loginId);
+
+    StepVerifier.create(notificationSummary)
+        .expectNextMatches(summary ->
+            summary.getNotifications().equals(1) &&
+                summary.getStandardActions().equals(3) &&
+                summary.getOverdueActions().equals(2)
+        )
+        .verifyComplete();
+  }
+
+  @Test
+  void getUserNotificationSummary_NotFound() {
+    final String loginId = "user1";
+    final String expectedUri = "/users/{loginId}/notifications/summary";
+
+    final NotificationSummary mockNotificationSummary = new NotificationSummary();
+    mockNotificationSummary.setNotifications(1);
+    mockNotificationSummary.setStandardActions(3);
+    mockNotificationSummary.setOverdueActions(2);
+
+    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+    when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
+    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+    when(responseMock.bodyToMono(NotificationSummary.class)).thenReturn(
+        Mono.just(mockNotificationSummary));
+
+    final Mono<NotificationSummary> notificationSummary = ebsApiClient.getUserNotificationSummary(
+        loginId);
+
+    StepVerifier.create(notificationSummary)
+        .expectNextMatches(summary ->
+            summary.getNotifications().equals(1) &&
+                summary.getStandardActions().equals(3) &&
+                summary.getOverdueActions().equals(2)
+        )
         .verifyComplete();
   }
 

--- a/src/test/java/uk/gov/laa/ccms/caab/client/SoaApiClientTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/client/SoaApiClientTest.java
@@ -37,7 +37,6 @@ import uk.gov.laa.ccms.soa.gateway.model.ContractDetails;
 import uk.gov.laa.ccms.soa.gateway.model.CoverSheet;
 import uk.gov.laa.ccms.soa.gateway.model.Document;
 import uk.gov.laa.ccms.soa.gateway.model.NameDetail;
-import uk.gov.laa.ccms.soa.gateway.model.NotificationSummary;
 import uk.gov.laa.ccms.soa.gateway.model.Notifications;
 import uk.gov.laa.ccms.soa.gateway.model.OrganisationDetail;
 import uk.gov.laa.ccms.soa.gateway.model.OrganisationDetails;
@@ -67,64 +66,6 @@ class SoaApiClientTest {
   @InjectMocks
   private SoaApiClient soaApiClient;
 
-  @Test
-  void getNotificationsSummary_returnData() {
-
-    String loginId = "user1";
-    String userType = "userType";
-    String expectedUri = "/users/{loginId}/notifications/summary";
-
-    NotificationSummary mockSummary = new NotificationSummary()
-        .notifications(10)
-        .standardActions(5)
-        .overdueActions(2);
-
-    when(soaApiWebClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.header("SoaGateway-User-Login-Id", loginId)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.header("SoaGateway-User-Role", userType)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(NotificationSummary.class)).thenReturn(Mono.just(mockSummary));
-
-    Mono<NotificationSummary> summaryMono =
-        soaApiClient.getNotificationsSummary(loginId, userType);
-
-    StepVerifier.create(summaryMono)
-        .expectNextMatches(summary ->
-            summary.getNotifications() == 10 &&
-                summary.getStandardActions() == 5 &&
-                summary.getOverdueActions() == 2)
-        .verifyComplete();
-  }
-
-  @Test
-  void getNotificationsSummary_notFound() {
-    String loginId = "user1";
-    String userType = "userType";
-    String expectedUri = "/users/{loginId}/notifications/summary";
-
-    when(soaApiWebClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.header("SoaGateway-User-Login-Id", loginId)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.header("SoaGateway-User-Role", userType)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(NotificationSummary.class)).thenReturn(Mono.error(
-        new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
-
-    when(apiClientErrorHandler.handleApiRetrieveError(
-        any(), eq("Notification summary"), eq("user login id"), eq(loginId)))
-        .thenReturn(Mono.empty());
-
-    Mono<NotificationSummary> summaryMono =
-        soaApiClient.getNotificationsSummary(loginId, userType);
-
-    StepVerifier.create(summaryMono)
-        .verifyComplete();
-  }
 
   @Test
   void getContractDetails_returnsData() {

--- a/src/test/java/uk/gov/laa/ccms/caab/controller/HomeControllerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/controller/HomeControllerTest.java
@@ -80,8 +80,8 @@ public class HomeControllerTest {
         .overdueActions(overdueActions);
 
     // Mock the SOA Gateway service to return the notification summary
-    when(notificationService.getNotificationsSummary(userDetails.getLoginId(),
-        userDetails.getUserType())).thenReturn(Mono.just(notificationSummary));
+    when(notificationService.getNotificationsSummary(userDetails.getLoginId())).thenReturn(
+        Mono.just(notificationSummary));
 
     this.mockMvc.perform(get("/").flashAttr("user", userDetails))
         .andDo(print())
@@ -98,8 +98,8 @@ public class HomeControllerTest {
   public void testHomeHandlesNullNotifications() throws Exception {
 
     // Mock the SOA Gateway service to return the notification summary
-    when(notificationService.getNotificationsSummary(userDetails.getLoginId(),
-        userDetails.getUserType())).thenReturn(Mono.empty());
+    when(notificationService.getNotificationsSummary(userDetails.getLoginId())).thenReturn(
+        Mono.empty());
 
     this.mockMvc.perform(get("/").flashAttr("user", userDetails))
         .andDo(print())

--- a/src/test/java/uk/gov/laa/ccms/caab/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/service/NotificationServiceTest.java
@@ -25,6 +25,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import uk.gov.laa.ccms.caab.bean.NotificationSearchCriteria;
 import uk.gov.laa.ccms.caab.client.CaabApiClient;
+import uk.gov.laa.ccms.caab.client.EbsApiClient;
 import uk.gov.laa.ccms.caab.client.S3ApiClient;
 import uk.gov.laa.ccms.caab.client.SoaApiClient;
 import uk.gov.laa.ccms.caab.exception.CaabApplicationException;
@@ -49,6 +50,9 @@ class NotificationServiceTest {
   private CaabApiClient caabApiClient;
 
   @Mock
+  private EbsApiClient ebsApiClient;
+
+  @Mock
   private NotificationAttachmentMapper notificationAttachmentMapper;
 
   @Mock
@@ -61,17 +65,16 @@ class NotificationServiceTest {
   void getNotificationsSummary_returnData() {
 
     String loginId = "user1";
-    String userType = "userType";
 
     NotificationSummary mockSummary = new NotificationSummary()
         .notifications(10)
         .standardActions(5)
         .overdueActions(2);
 
-    when(soaApiClient.getNotificationsSummary(loginId, userType)).thenReturn(Mono.just(mockSummary));
+    when(ebsApiClient.getUserNotificationSummary(loginId)).thenReturn(Mono.just(mockSummary));
 
     Mono<NotificationSummary> summaryMono =
-        notificationService.getNotificationsSummary(loginId, userType);
+        notificationService.getNotificationsSummary(loginId);
 
     StepVerifier.create(summaryMono)
         .expectNextMatches(summary ->


### PR DESCRIPTION
As part of CBP-947, work was done to move the notification summary from SOA to EBS, which resulted in a new view XXCCMS_NOTIFICATION_COUNT_V being created to support this. 

As part of this PR and CCMSPUI-376, the old method in SoaApiClient has been removed, and a new method has been added in EbsApiClient to use the new endpoint added as part of this PR:
https://github.com/ministryofjustice/laa-ccms-data-api/pull/119