### PR TITLE
Update soa-api version to 0.0.39

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
 	implementation 'uk.gov.laa.ccms.data:data-api:0.0.22-ef3e97c-SNAPSHOT'
 
-	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.38-cfdf45d-SNAPSHOT'
+	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.39'
 
 	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.37'
 


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update soa-api version to 0.0.39