### PR TITLE
CCMSPUI-378: Replace get reference data from SOA-API to EBS-API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,7 @@ repositories {
 
 dependencies {
 
-
-	implementation 'uk.gov.laa.ccms.data:data-api:0.0.22-ef3e97c-SNAPSHOT'
+	implementation 'uk.gov.laa.ccms.data:data-api:0.0.23-70d39c3-SNAPSHOT'
 
 	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.38-cfdf45d-SNAPSHOT'
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
 	implementation 'uk.gov.laa.ccms.data:data-api:0.0.23-70d39c3-SNAPSHOT'
 
-	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.38-cfdf45d-SNAPSHOT'
+	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.40-18b2f2e-SNAPSHOT'
 
 	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.37'
 

--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/SoaApiClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/SoaApiClientIntegrationTest.java
@@ -24,7 +24,6 @@ import uk.gov.laa.ccms.caab.bean.CaseSearchCriteria;
 import uk.gov.laa.ccms.caab.bean.NotificationSearchCriteria;
 import uk.gov.laa.ccms.soa.gateway.model.BaseClient;
 import uk.gov.laa.ccms.soa.gateway.model.CaseDetails;
-import uk.gov.laa.ccms.soa.gateway.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.soa.gateway.model.CaseSummary;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetail;
 import uk.gov.laa.ccms.soa.gateway.model.ClientTransactionResponse;
@@ -140,27 +139,6 @@ public class SoaApiClientIntegrationTest extends AbstractIntegrationTest {
     ClientDetail response = clientMono.block();
 
     assertEquals(clientDetail, response);
-  }
-
-  @Test
-  public void testGetCaseReference_returnData() throws Exception {
-    String loginId = USER_1;
-    String userType = USER_TYPE;
-    CaseReferenceSummary caseReferenceSummary =
-        new CaseReferenceSummary(); // Fill with appropriate data
-    String caseReferenceJson = objectMapper.writeValueAsString(caseReferenceSummary);
-
-    wiremock.stubFor(get("/case-reference")
-        .withHeader(SOA_GATEWAY_USER_LOGIN_ID, equalTo(loginId))
-        .withHeader(SOA_GATEWAY_USER_ROLE, equalTo(userType))
-        .willReturn(okJson(caseReferenceJson)));
-
-    Mono<CaseReferenceSummary> caseReferenceMono =
-        soaApiClient.getCaseReference(loginId, userType);
-
-    CaseReferenceSummary response = caseReferenceMono.block();
-
-    assertEquals(caseReferenceSummary, response);
   }
 
   @Test

--- a/src/main/java/uk/gov/laa/ccms/caab/builders/InitialApplicationBuilder.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/builders/InitialApplicationBuilder.java
@@ -18,9 +18,9 @@ import uk.gov.laa.ccms.caab.model.StringDisplayValue;
 import uk.gov.laa.ccms.data.model.AmendmentTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.AmendmentTypeLookupValueDetail;
 import uk.gov.laa.ccms.data.model.BaseOffice;
+import uk.gov.laa.ccms.data.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.data.model.CategoryOfLawLookupValueDetail;
 import uk.gov.laa.ccms.data.model.UserDetail;
-import uk.gov.laa.ccms.soa.gateway.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.soa.gateway.model.ContractDetail;
 
 /**

--- a/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
@@ -767,7 +767,7 @@ public class EbsApiClient {
    * reference service.
    *
    * @return a {@link Mono} emitting the {@link CaseReferenceSummary} containing the details of the
-   * next allocated case reference
+   *     next allocated case reference
    */
   public Mono<CaseReferenceSummary> postAllocateNextCaseReference() {
     return ebsApiWebClient

--- a/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
@@ -11,6 +11,7 @@ import reactor.core.publisher.Mono;
 import uk.gov.laa.ccms.data.model.AmendmentTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.AssessmentSummaryEntityLookupDetail;
 import uk.gov.laa.ccms.data.model.AwardTypeLookupDetail;
+import uk.gov.laa.ccms.data.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.data.model.CaseStatusLookupDetail;
 import uk.gov.laa.ccms.data.model.CategoryOfLawLookupDetail;
 import uk.gov.laa.ccms.data.model.ClientInvolvementTypeLookupDetail;
@@ -761,6 +762,22 @@ public class EbsApiClient {
             e, "Provider request types", queryParams));
   }
 
+  /**
+   * Allocates the next available case reference by sending a POST request to the external case
+   * reference service.
+   *
+   * @return a {@link Mono} emitting the {@link CaseReferenceSummary} containing the details of the
+   * next allocated case reference
+   */
+  public Mono<CaseReferenceSummary> postAllocateNextCaseReference() {
+    return ebsApiWebClient
+        .post()
+        .uri("/case-reference")
+        .retrieve()
+        .bodyToMono(CaseReferenceSummary.class)
+        .onErrorResume(e -> ebsApiClientErrorHandler.handleApiRetrieveError(
+            e, "case reference", null));
+  }
 
 }
 

--- a/src/main/java/uk/gov/laa/ccms/caab/client/SoaApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/SoaApiClient.java
@@ -19,7 +19,6 @@ import uk.gov.laa.ccms.caab.bean.NotificationSearchCriteria;
 import uk.gov.laa.ccms.caab.bean.opponent.OrganisationSearchCriteria;
 import uk.gov.laa.ccms.soa.gateway.model.CaseDetail;
 import uk.gov.laa.ccms.soa.gateway.model.CaseDetails;
-import uk.gov.laa.ccms.soa.gateway.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.soa.gateway.model.CaseTransactionResponse;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetail;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetailDetails;
@@ -367,28 +366,6 @@ public class SoaApiClient {
         .bodyToMono(TransactionStatus.class)
         .onErrorResume(e -> soaApiClientErrorHandler.handleApiRetrieveError(
             e, "case transaction status", "transaction id", transactionId));
-  }
-
-  /**
-   * Fetches a summary of case references.
-   *
-   * @param loginId  The login identifier for the user.
-   * @param userType Type of the user (e.g., admin, user).
-   * @return A Mono wrapping the CaseReferenceSummary.
-   */
-  public Mono<CaseReferenceSummary> getCaseReference(
-      final String loginId,
-      final String userType) {
-    return soaApiWebClient
-        .get()
-        .uri("/case-reference")
-        .header(SOA_GATEWAY_USER_LOGIN_ID, loginId)
-        .header(SOA_GATEWAY_USER_ROLE, userType)
-        .retrieve()
-        .bodyToMono(CaseReferenceSummary.class)
-        .onErrorResume(e -> soaApiClientErrorHandler.handleApiRetrieveError(
-            e, "case reference", null));
-
   }
 
   /**

--- a/src/main/java/uk/gov/laa/ccms/caab/service/ApplicationService.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/service/ApplicationService.java
@@ -100,6 +100,7 @@ import uk.gov.laa.ccms.caab.util.ReflectionUtils;
 import uk.gov.laa.ccms.data.model.AmendmentTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.AwardTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.AwardTypeLookupValueDetail;
+import uk.gov.laa.ccms.data.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.data.model.CaseStatusLookupDetail;
 import uk.gov.laa.ccms.data.model.CaseStatusLookupValueDetail;
 import uk.gov.laa.ccms.data.model.CategoryOfLawLookupValueDetail;
@@ -121,7 +122,6 @@ import uk.gov.laa.ccms.soa.gateway.model.AssessmentResult;
 import uk.gov.laa.ccms.soa.gateway.model.Award;
 import uk.gov.laa.ccms.soa.gateway.model.CaseDetail;
 import uk.gov.laa.ccms.soa.gateway.model.CaseDetails;
-import uk.gov.laa.ccms.soa.gateway.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.soa.gateway.model.CaseTransactionResponse;
 import uk.gov.laa.ccms.soa.gateway.model.CategoryOfLaw;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetail;
@@ -317,7 +317,7 @@ public class ApplicationService {
    * @return A Mono wrapping the CaseReferenceSummary.
    */
   public Mono<CaseReferenceSummary> getCaseReference(final String loginId, final String userType) {
-    return soaApiClient.getCaseReference(loginId, userType);
+    return ebsApiClient.postAllocateNextCaseReference();
   }
 
   /**

--- a/src/main/resources/templates/partials/header.html
+++ b/src/main/resources/templates/partials/header.html
@@ -39,7 +39,7 @@
                                 Home
                             </a>
                         </li>
-                        <li th:if="${#lists.contains(user.functions, 'YCA')}"
+                        <li th:if="${#lists.contains(user?.functions, 'YCA')}"
                             class="govuk-service-navigation__item"
                             th:classappend="${pageCategory == 'cases'} ? 'govuk-service-navigation__item--active'">
                             <a class="govuk-service-navigation__link"
@@ -49,7 +49,7 @@
                                     applications</strong>
                             </a>
                         </li>
-                        <li th:if="${#lists.contains(user.functions, 'NOT')}"
+                        <li th:if="${#lists.contains(user?.functions, 'NOT')}"
                             class="govuk-service-navigation__item"
                             th:classappend="${pageCategory == 'actions'} ? 'govuk-service-navigation__item--active'">
                             <a class="govuk-service-navigation__link"

--- a/src/test/java/uk/gov/laa/ccms/caab/builders/InitialApplicationBuilderTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/builders/InitialApplicationBuilderTest.java
@@ -15,9 +15,9 @@ import uk.gov.laa.ccms.data.model.AmendmentTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.AmendmentTypeLookupValueDetail;
 import uk.gov.laa.ccms.data.model.BaseOffice;
 import uk.gov.laa.ccms.data.model.BaseProvider;
+import uk.gov.laa.ccms.data.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.data.model.CategoryOfLawLookupValueDetail;
 import uk.gov.laa.ccms.data.model.UserDetail;
-import uk.gov.laa.ccms.soa.gateway.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.soa.gateway.model.ContractDetail;
 
 class InitialApplicationBuilderTest {

--- a/src/test/java/uk/gov/laa/ccms/caab/client/SoaApiClientTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/client/SoaApiClientTest.java
@@ -28,7 +28,6 @@ import uk.gov.laa.ccms.caab.bean.NotificationSearchCriteria;
 import uk.gov.laa.ccms.caab.bean.opponent.OrganisationSearchCriteria;
 import uk.gov.laa.ccms.soa.gateway.model.CaseDetail;
 import uk.gov.laa.ccms.soa.gateway.model.CaseDetails;
-import uk.gov.laa.ccms.soa.gateway.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetail;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetailDetails;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetails;
@@ -345,58 +344,6 @@ class SoaApiClientTest {
         soaApiClient.getClient(clientReferenceNumber, loginId, userType);
 
     StepVerifier.create(clientDetailMono)
-        .verifyComplete();
-  }
-
-  @Test
-  void getCaseReference_returnsCaseReferenceSummary_Successful() {
-    String loginId = "user1";
-    String userType = "userType";
-    String expectedUri = "/case-reference";
-
-    CaseReferenceSummary mockCaseReferenceSummary = new CaseReferenceSummary();
-
-    when(soaApiWebClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(expectedUri)).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.header("SoaGateway-User-Login-Id", loginId)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.header("SoaGateway-User-Role", userType)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CaseReferenceSummary.class)).thenReturn(
-        Mono.just(mockCaseReferenceSummary));
-
-    Mono<CaseReferenceSummary> caseReferenceSummaryMono =
-        soaApiClient.getCaseReference(loginId, userType);
-
-    StepVerifier.create(caseReferenceSummaryMono)
-        .expectNextMatches(summary -> summary == mockCaseReferenceSummary)
-        .verifyComplete();
-  }
-
-  @Test
-  void getCaseReference_handlesError() {
-    String loginId = "user1";
-    String userType = "userType";
-    String expectedUri = "/case-reference";
-
-    when(soaApiWebClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(expectedUri)).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.header("SoaGateway-User-Login-Id", loginId)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.header("SoaGateway-User-Role", userType)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CaseReferenceSummary.class)).thenReturn(Mono.error(
-        new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
-
-    when(apiClientErrorHandler.handleApiRetrieveError(
-        any(), eq("case reference"), eq(null))).thenReturn(Mono.empty());
-
-    Mono<CaseReferenceSummary> caseReferenceSummaryMono =
-        soaApiClient.getCaseReference(loginId, userType);
-
-    StepVerifier.create(caseReferenceSummaryMono)
         .verifyComplete();
   }
 

--- a/src/test/java/uk/gov/laa/ccms/caab/service/ApplicationServiceTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/service/ApplicationServiceTest.java
@@ -45,6 +45,7 @@ import static uk.gov.laa.ccms.caab.constants.assessment.AssessmentName.MERITS_PR
 import static uk.gov.laa.ccms.caab.util.CaabModelUtils.buildApplicationDetail;
 import static uk.gov.laa.ccms.caab.util.CaabModelUtils.buildApplicationProviderDetails;
 import static uk.gov.laa.ccms.caab.util.CaabModelUtils.buildOpponent;
+import static uk.gov.laa.ccms.caab.util.EbsModelUtils.buildCaseReferenceSummary;
 import static uk.gov.laa.ccms.caab.util.EbsModelUtils.buildCategoryOfLawLookupValueDetail;
 import static uk.gov.laa.ccms.caab.util.EbsModelUtils.buildPriorAuthorityTypeDetails;
 import static uk.gov.laa.ccms.caab.util.EbsModelUtils.buildProviderDetail;
@@ -52,7 +53,6 @@ import static uk.gov.laa.ccms.caab.util.EbsModelUtils.buildRelationshipToCaseLoo
 import static uk.gov.laa.ccms.caab.util.EbsModelUtils.buildUserDetail;
 import static uk.gov.laa.ccms.caab.util.SoaModelUtils.buildAwardTypeLookupDetail;
 import static uk.gov.laa.ccms.caab.util.SoaModelUtils.buildCaseDetail;
-import static uk.gov.laa.ccms.caab.util.SoaModelUtils.buildCaseReferenceSummary;
 import static uk.gov.laa.ccms.caab.util.SoaModelUtils.buildClientDetail;
 import static uk.gov.laa.ccms.caab.util.SoaModelUtils.buildPriorAuthority;
 import static uk.gov.laa.ccms.caab.util.SoaModelUtils.buildProceedingDetail;
@@ -124,6 +124,7 @@ import uk.gov.laa.ccms.data.model.AmendmentTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.AmendmentTypeLookupValueDetail;
 import uk.gov.laa.ccms.data.model.AwardTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.AwardTypeLookupValueDetail;
+import uk.gov.laa.ccms.data.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.data.model.CaseStatusLookupDetail;
 import uk.gov.laa.ccms.data.model.CaseStatusLookupValueDetail;
 import uk.gov.laa.ccms.data.model.CategoryOfLawLookupValueDetail;
@@ -144,7 +145,6 @@ import uk.gov.laa.ccms.data.model.StageEndLookupValueDetail;
 import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.soa.gateway.model.CaseDetail;
 import uk.gov.laa.ccms.soa.gateway.model.CaseDetails;
-import uk.gov.laa.ccms.soa.gateway.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.soa.gateway.model.CaseSummary;
 import uk.gov.laa.ccms.soa.gateway.model.ContractDetails;
 import uk.gov.laa.ccms.soa.gateway.model.PriorAuthority;
@@ -200,7 +200,7 @@ class ApplicationServiceTest {
 
     final CaseReferenceSummary mockCaseReferenceSummary = new CaseReferenceSummary();
 
-    when(soaApiClient.getCaseReference(loginId, userType)).thenReturn(
+    when(ebsApiClient.postAllocateNextCaseReference()).thenReturn(
         Mono.just(mockCaseReferenceSummary));
 
     final Mono<CaseReferenceSummary> caseReferenceSummaryMono =
@@ -480,7 +480,7 @@ class ApplicationServiceTest {
     final AmendmentTypeLookupDetail amendmentTypes =
         new AmendmentTypeLookupDetail().addContentItem(amendmentType);
 
-    when(soaApiClient.getCaseReference(user.getLoginId(), user.getUserType())).thenReturn(
+    when(ebsApiClient.postAllocateNextCaseReference()).thenReturn(
         Mono.just(caseReferenceSummary));
     when(soaApiClient.getContractDetails(anyInt(), anyInt(), anyString(),
         anyString())).thenReturn(Mono.just(contractDetails));
@@ -495,7 +495,7 @@ class ApplicationServiceTest {
     StepVerifier.create(applicationMono)
         .verifyComplete();
 
-    verify(soaApiClient).getCaseReference(user.getLoginId(), user.getUserType());
+    verify(ebsApiClient).postAllocateNextCaseReference();
     verify(lookupService).getCategoryOfLaw(applicationFormData.getCategoryOfLawId());
     verify(soaApiClient).getContractDetails(anyInt(), anyInt(), anyString(), anyString());
     verify(ebsApiClient).getAmendmentTypes(any());
@@ -524,7 +524,7 @@ class ApplicationServiceTest {
     when(soaApiClient.getCase(copyCaseReference, user.getLoginId(), user.getUserType()))
         .thenReturn(Mono.just(soaCase));
 
-    when(soaApiClient.getCaseReference(user.getLoginId(), user.getUserType()))
+    when(ebsApiClient.postAllocateNextCaseReference())
         .thenReturn(Mono.just(caseReferenceSummary));
 
     /* START ApplicationMappingContext */
@@ -710,7 +710,7 @@ class ApplicationServiceTest {
     applicationToCopy.getOpponents().get(0).setType(opponentType);
     applicationToCopy.getOpponents().get(0).setSharedInd(opponentShared);
 
-    when(soaApiClient.getCaseReference(userDetail.getLoginId(), userDetail.getUserType()))
+    when(ebsApiClient.postAllocateNextCaseReference())
         .thenReturn(Mono.just(caseReferenceSummary));
 
     CategoryOfLawLookupValueDetail categoryOfLawLookupValueDetail =

--- a/src/test/java/uk/gov/laa/ccms/caab/util/EbsModelUtils.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/util/EbsModelUtils.java
@@ -1,7 +1,9 @@
 package uk.gov.laa.ccms.caab.util;
 
+import java.util.UUID;
 import uk.gov.laa.ccms.data.model.BaseOffice;
 import uk.gov.laa.ccms.data.model.BaseProvider;
+import uk.gov.laa.ccms.data.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.data.model.CategoryOfLawLookupValueDetail;
 import uk.gov.laa.ccms.data.model.ContactDetail;
 import uk.gov.laa.ccms.data.model.OfficeDetail;
@@ -100,4 +102,8 @@ public class EbsModelUtils {
                 .copyParty(Boolean.TRUE));
   }
 
+  public static CaseReferenceSummary buildCaseReferenceSummary() {
+    return new CaseReferenceSummary()
+        .caseReferenceNumber(UUID.randomUUID().toString());
+  }
 }

--- a/src/test/java/uk/gov/laa/ccms/caab/util/SoaModelUtils.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/util/SoaModelUtils.java
@@ -9,18 +9,15 @@ import static uk.gov.laa.ccms.caab.constants.ApplicationConstants.STATUS_DRAFT;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.UUID;
 import uk.gov.laa.ccms.data.model.AwardTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.AwardTypeLookupValueDetail;
 import uk.gov.laa.ccms.soa.gateway.model.AddressDetail;
-import uk.gov.laa.ccms.soa.gateway.model.SubmittedApplicationDetails;
 import uk.gov.laa.ccms.soa.gateway.model.AssessmentScreen;
 import uk.gov.laa.ccms.soa.gateway.model.Award;
 import uk.gov.laa.ccms.soa.gateway.model.BaseClient;
 import uk.gov.laa.ccms.soa.gateway.model.BaseContact;
 import uk.gov.laa.ccms.soa.gateway.model.CaseDetail;
 import uk.gov.laa.ccms.soa.gateway.model.CaseDoc;
-import uk.gov.laa.ccms.soa.gateway.model.CaseReferenceSummary;
 import uk.gov.laa.ccms.soa.gateway.model.CaseStatus;
 import uk.gov.laa.ccms.soa.gateway.model.CaseSummary;
 import uk.gov.laa.ccms.soa.gateway.model.CategoryOfLaw;
@@ -56,6 +53,7 @@ import uk.gov.laa.ccms.soa.gateway.model.Recovery;
 import uk.gov.laa.ccms.soa.gateway.model.RecoveryAmount;
 import uk.gov.laa.ccms.soa.gateway.model.ScopeLimitation;
 import uk.gov.laa.ccms.soa.gateway.model.ServiceAddress;
+import uk.gov.laa.ccms.soa.gateway.model.SubmittedApplicationDetails;
 import uk.gov.laa.ccms.soa.gateway.model.TimeRelatedAward;
 import uk.gov.laa.ccms.soa.gateway.model.UserDetail;
 import uk.gov.laa.ccms.soa.gateway.model.Valuation;
@@ -590,11 +588,6 @@ public class SoaModelUtils {
         .remainderAuthorisation(remainderAuth)
         .contractualDevolvedPowers("CATDEVPOW")
         .authorisationType("AUTHTYPE1");
-  }
-
-  public static CaseReferenceSummary buildCaseReferenceSummary() {
-    return new CaseReferenceSummary()
-        .caseReferenceNumber(UUID.randomUUID().toString());
   }
 
   public static CaseSummary buildCaseSummary() {


### PR DESCRIPTION
SOA is a pain point for PUI due to the slow response times. As part of the wider piece of work to deprecate SOA, SOA methods have been migrated to views within the EBS database. This PR is to reflect some of this work.

As part of this PR, old references to use the SOA API to get the next case reference has been swapped to use the EBS API.