### PR TITLE
Removed unused parameters found in ApplicationService getCaseReference() method

### DIFF
--- a/src/main/java/uk/gov/laa/ccms/caab/service/ApplicationService.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/service/ApplicationService.java
@@ -312,11 +312,9 @@ public class ApplicationService {
   /**
    * Fetches a unique case reference.
    *
-   * @param loginId  The login identifier for the user.
-   * @param userType Type of the user (e.g., admin, user).
    * @return A Mono wrapping the CaseReferenceSummary.
    */
-  public Mono<CaseReferenceSummary> getCaseReference(final String loginId, final String userType) {
+  public Mono<CaseReferenceSummary> getCaseReference() {
     return ebsApiClient.postAllocateNextCaseReference();
   }
 
@@ -373,7 +371,7 @@ public class ApplicationService {
         ContractDetails,
         AmendmentTypeLookupDetail>> combinedResult =
         Mono.zip(
-            this.getCaseReference(user.getLoginId(), user.getUserType()),
+            this.getCaseReference(),
             lookupService.getCategoryOfLaw(applicationFormData.getCategoryOfLawId()),
             soaApiClient.getContractDetails(
                 user.getProvider().getId(),
@@ -426,7 +424,7 @@ public class ApplicationService {
         ContractDetails,
         RelationshipToCaseLookupDetail>> combinedResult =
         Mono.zip(
-            this.getCaseReference(user.getLoginId(), user.getUserType()),
+            this.getCaseReference(),
             lookupService.getCategoryOfLaw(applicationToCopy.getCategoryOfLaw().getId()),
             soaApiClient.getContractDetails(
                 user.getProvider().getId(),

--- a/src/test/java/uk/gov/laa/ccms/caab/service/ApplicationServiceTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/service/ApplicationServiceTest.java
@@ -195,8 +195,6 @@ class ApplicationServiceTest {
 
   @Test
   void getCaseReference_returnsCaseReferenceSummary_Successful() {
-    final String loginId = "user1";
-    final String userType = "userType";
 
     final CaseReferenceSummary mockCaseReferenceSummary = new CaseReferenceSummary();
 
@@ -204,7 +202,7 @@ class ApplicationServiceTest {
         Mono.just(mockCaseReferenceSummary));
 
     final Mono<CaseReferenceSummary> caseReferenceSummaryMono =
-        applicationService.getCaseReference(loginId, userType);
+        applicationService.getCaseReference();
 
     StepVerifier.create(caseReferenceSummaryMono)
         .expectNextMatches(summary -> summary == mockCaseReferenceSummary)


### PR DESCRIPTION
Two parameters are removed which were found in the getCaseReference method as they're not needed by ebsApiClient.