### PR TITLE
Fix: [CCMSPUI 106] Vulnerability Report Publishing

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -83,10 +83,14 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-22.04
 
+    permissions:
+      security-events: write
+
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       SNYK_ORG: legal-aid-agency
       SNYK_TEST_EXCLUDE: build
+      GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
 
     steps:
       - uses: actions/checkout@v3
@@ -96,22 +100,18 @@ jobs:
         with:
           command: monitor
           args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
       - name: Generate sarif Snyk report
         uses: snyk/actions/gradle@0.4.0
         continue-on-error: true
         with:
           args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE --sarif-file-output=snyk-report.sarif
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk-report.sarif
 
   ecr:
-    needs: [ build-test, define-image-tag ]
+    needs: [ build-test, vulnerability-report, define-image-tag ]
     runs-on: ubuntu-latest
     permissions:
       id-token: write # for requesting jwt

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -99,16 +99,38 @@ jobs:
         continue-on-error: true
         with:
           command: monitor
-          args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE
+          args: --org=$SNYK_ORG --all-projects --exclude=$SNYK_TEST_EXCLUDE
       - name: Generate sarif Snyk report
         uses: snyk/actions/gradle@0.4.0
         continue-on-error: true
         with:
-          args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE --sarif-file-output=snyk-report.sarif
+          args: --org=$SNYK_ORG --all-projects --exclude=$SNYK_TEST_EXCLUDE --sarif-file-output=snyk-report.sarif
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+      - name: Fix undefined values
+        run: |
+          cat snyk-report.sarif | jq '
+              .runs[].tool[].rules[]
+              |= (
+                  if .properties["security-severity"] == "undefined"
+                  then .properties["security-severity"] =
+                   (  if .shortDescription.text | test("(?i)critical") then "9.0"
+                      elif .shortDescription.text | test("(?i)high") then "7.0"
+                      elif .shortDescription.text | test("(?i)medium") then "4.0"
+                      elif .shortDescription.text | test("(?i)low") then "0.1"
+                      else ""
+                      end
+                   )
+                   else .
+                   end
+               )
+          ' > snyk-report-cleansed.sarif
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: snyk-report.sarif
+          sarif_file: snyk-report-cleansed.sarif
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
 
   ecr:
     needs: [ build-test, vulnerability-report, define-image-tag ]

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -59,9 +59,6 @@ jobs:
   vulnerability-scan:
     runs-on: ubuntu-22.04
 
-    permissions:
-      security-events: write
-
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       SNYK_ORG: legal-aid-agency
@@ -85,35 +82,3 @@ jobs:
         with:
           command: code test
           args: --org=${SNYK_ORG}
-      ### testing
-      - name: Generate sarif Snyk report
-        uses: snyk/actions/gradle@0.4.0
-        continue-on-error: true
-        with:
-          args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE --sarif-file-output=snyk-report.sarif
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
-      - name: Fix undefined values
-        run: |
-          cat snyk-report.sarif | jq '
-              .runs[].tool[].rules[]
-              |= (
-                  if .properties["security-severity"] == "undefined"
-                  then .properties["security-severity"] =
-                   (  if .shortDescription.text | test("(?i)critical") then "9.0"
-                      elif .shortDescription.text | test("(?i)high") then "7.0"
-                      elif .shortDescription.text | test("(?i)medium") then "4.0"
-                      elif .shortDescription.text | test("(?i)low") then "0.1"
-                      else ""
-                      end
-                   )
-                   else .
-                   end
-               )
-          ' > snyk-report-cleansed.sarif
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: snyk-report-cleansed.sarif
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -69,11 +69,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          java-version: '21'
-          distribution: 'temurin'
       - uses: snyk/actions/setup@0.4.0
       - name: Install snyk-delta
         run: |

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -110,10 +110,10 @@ jobs:
                    else .
                    end
                )
-          ' > snyk-report.sarif
+          ' > snyk-report-cleansed.sarif
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: snyk-report.sarif
+          sarif_file: snyk-report-cleansed.sarif
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -91,6 +91,8 @@ jobs:
         continue-on-error: true
         with:
           args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE --sarif-file-output=snyk-report.sarif
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -59,6 +59,9 @@ jobs:
   vulnerability-scan:
     runs-on: ubuntu-22.04
 
+    permissions:
+      security-events: write
+
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       SNYK_ORG: legal-aid-agency
@@ -87,3 +90,15 @@ jobs:
         with:
           command: code test
           args: --org=${SNYK_ORG}
+      ### testing
+      - name: Generate sarif Snyk report
+        uses: snyk/actions/gradle@0.4.0
+        continue-on-error: true
+        with:
+          args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE --sarif-file-output=snyk-report.sarif
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk-report.sarif
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -98,8 +98,8 @@ jobs:
           cat snyk-report.sarif | jq '
               .runs[].tool[].rules[]
               |= (
-                  if .properties.["security-severity"] == "undefined"
-                  then .properties.["security-severity"] =
+                  if .properties["security-severity"] == "undefined"
+                  then .properties["security-severity"] =
                    (  if .shortDescription.text | test("(?i)critical") then "critical"
                       elif .shortDescription.text | test("(?i)high") then "high"
                       elif .shortDescription.text | test("(?i)medium") then "medium"

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -93,6 +93,24 @@ jobs:
           args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE --sarif-file-output=snyk-report.sarif
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+      - name: Fix undefined values
+        run: |
+          cat snyk-report.sarif | jq '
+              .runs[].tool[].rules[]
+              |= (
+                  if .properties.["security-severity"] == "undefined"
+                  then .properties.["security-severity"] =
+                   (  if .shortDescription.text | test("(?i)critical") then "critical"
+                      elif .shortDescription.text | test("(?i)high") then "high"
+                      elif .shortDescription.text | test("(?i)medium") then "medium"
+                      elif .shortDescription.text | test("(?i)low") then "low"
+                      else "undefined"
+                      end
+                   )
+                   else .
+                   end
+               )
+          ' > snyk-report.sarif
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -100,11 +100,11 @@ jobs:
               |= (
                   if .properties["security-severity"] == "undefined"
                   then .properties["security-severity"] =
-                   (  if .shortDescription.text | test("(?i)critical") then "critical"
-                      elif .shortDescription.text | test("(?i)high") then "high"
-                      elif .shortDescription.text | test("(?i)medium") then "medium"
-                      elif .shortDescription.text | test("(?i)low") then "low"
-                      else "undefined"
+                   (  if .shortDescription.text | test("(?i)critical") then "9.0"
+                      elif .shortDescription.text | test("(?i)high") then "7.0"
+                      elif .shortDescription.text | test("(?i)medium") then "4.0"
+                      elif .shortDescription.text | test("(?i)low") then "0.1"
+                      else ""
                       end
                    )
                    else .


### PR DESCRIPTION
* Snyk-generated sarif report contained `security-severity` values that were not supported by GitHub Code Scanning. A new step has been added to pre-process these values.
  * If the value is 'undefined', a the severity from the textual description will be used and converted to the appropriate numerical value, otherwise the property will be unset.