### PR TITLE
Fix: [CCMSPUI 514] Make action param optional

### DIFF
--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/client/ClientAddressDetailsController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/client/ClientAddressDetailsController.java
@@ -89,7 +89,7 @@ public class ClientAddressDetailsController {
    */
   @PostMapping("/application/client/details/address")
   public String clientDetailsAddress(
-      @RequestParam String action,
+      @RequestParam(required = false) String action,
       @SessionAttribute(CLIENT_FLOW_FORM_DATA) ClientFlowFormData clientFlowFormData,
       @ModelAttribute("addressDetails") ClientFormDataAddressDetails addressDetails,
       BindingResult bindingResult,

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/EditGeneralDetailsSectionController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/EditGeneralDetailsSectionController.java
@@ -133,7 +133,7 @@ public class EditGeneralDetailsSectionController {
    */
   @PostMapping("/application/sections/correspondence-address")
   public String updateCorrespondenceDetails(
-      @RequestParam final String action,
+      @RequestParam(required = false) final String action,
       @SessionAttribute(APPLICATION_ID) final String applicationId,
       @ModelAttribute("addressDetails") final AddressFormData addressDetails,
       @SessionAttribute(USER_DETAILS) final UserDetail user,

--- a/src/main/resources/templates/application/application-client-search.html
+++ b/src/main/resources/templates/application/application-client-search.html
@@ -45,9 +45,9 @@
                                 </span>
                             </p>
                             <div class="govuk-date-input" id="dob">
-                                <div th:replace="partials/forms::numericInput('dobDay', 'Day', '2')"></div>
-                                <div th:replace="partials/forms::numericInput('dobMonth', 'Month', '2')"></div>
-                                <div th:replace="partials/forms::numericInput('dobYear', 'Year', '4')"></div>
+                                <div th:replace="~{partials/forms::numericInput('dobDay', 'Day', '2')}"></div>
+                                <div th:replace="~{partials/forms::numericInput('dobMonth', 'Month', '2')}"></div>
+                                <div th:replace="~{partials/forms::numericInput('dobYear', 'Year', '4')}"></div>
                             </div>
                         </fieldset>
                     </div>


### PR DESCRIPTION
Small fix after recent changes to move towards use of dialects. The `action` request parameter would no longer be populated on submission of the address form pages. This change makes them optional as they are only needed when doing an address search.

This was blocking regression tests reaching the equal opportunities page, so will fix several of these tests.

Also removes warnings by properly encapsulating date fragment references.