### PR TITLE
CCMSPUI-462 Reimplement get client transaction status to use EBS API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,9 @@ repositories {
 
 dependencies {
 
-	implementation 'uk.gov.laa.ccms.data:data-api:0.0.30-bc6420d-SNAPSHOT'
+	implementation 'uk.gov.laa.ccms.data:data-api:0.0.35'
 
-	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.48'
+	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.49-2f86945-SNAPSHOT'
 
 	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.40'
 

--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/EbsApiClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/EbsApiClientIntegrationTest.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import java.util.ArrayList;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +46,7 @@ import uk.gov.laa.ccms.data.model.NotificationSummary;
 import uk.gov.laa.ccms.data.model.Notifications;
 import uk.gov.laa.ccms.data.model.OfficeDetail;
 import uk.gov.laa.ccms.data.model.ProviderDetail;
+import uk.gov.laa.ccms.data.model.TransactionStatus;
 import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.data.model.UserDetails;
 
@@ -350,6 +352,23 @@ public class EbsApiClientIntegrationTest extends AbstractIntegrationTest {
     assertNotNull(response);
     assertEquals(1, response.getContent().size());
     assertEquals(caseDetailsJson, objectMapper.writeValueAsString(response));
+  }
+
+  @Test
+  @DisplayName("Get client status should return data")
+  public void testGetClientStatus_returnData() throws JsonProcessingException {
+    // Given
+    TransactionStatus expected = new TransactionStatus().submissionStatus("Success").referenceNumber("123");
+    String transactionDetailsJson = objectMapper.writeValueAsString(expected);
+    String transactionId = "1234567890";
+    wiremock.stubFor(get(String.format("/clients/status/%s", transactionId)).willReturn(
+        okJson(transactionDetailsJson)
+    ));
+    // When
+    TransactionStatus response = ebsApiClient.getClientStatus(transactionId).block();
+    // Then
+    assertNotNull(response);
+    assertEquals(expected, response);
   }
 
   // You may need to build the AmendmentTypeLookupDetail for the test

--- a/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
@@ -35,6 +35,7 @@ import uk.gov.laa.ccms.data.model.ScopeLimitationDetails;
 import uk.gov.laa.ccms.data.model.StageEndLookupDetail;
 import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.data.model.UserDetails;
+import uk.gov.laa.ccms.soa.gateway.model.TransactionStatus;
 
 /**
  * Client class responsible for interacting with the ebs-api microservice to retrieve various data
@@ -827,6 +828,24 @@ public class EbsApiClient extends BaseApiClient {
         .bodyToMono(CaseDetails.class)
         .onErrorResume(e -> ebsApiClientErrorHandler.handleApiRetrieveError(
             e, "Cases", queryParams));
+  }
+
+  /**
+   * Fetches the transaction status for a client transaction.
+   *
+   * @param transactionId         The transaction id for the client transaction in soa.
+   * @return A Mono wrapping the TransactionStatus.
+   */
+  public Mono<TransactionStatus> getClientStatus(
+      final String transactionId) {
+    return webClient
+        .get()
+        .uri("/clients/status/{transactionId}", transactionId)
+        .retrieve()
+        .bodyToMono(TransactionStatus.class)
+        .onErrorResume(e -> ebsApiClientErrorHandler.handleApiRetrieveError(
+            e, "client transaction status", "transaction id", transactionId));
+
   }
 
   private static MultiValueMap<String, String> buildQueryParams(

--- a/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
@@ -33,9 +33,9 @@ import uk.gov.laa.ccms.data.model.RelationshipToCaseLookupDetail;
 import uk.gov.laa.ccms.data.model.ScopeLimitationDetail;
 import uk.gov.laa.ccms.data.model.ScopeLimitationDetails;
 import uk.gov.laa.ccms.data.model.StageEndLookupDetail;
+import uk.gov.laa.ccms.data.model.TransactionStatus;
 import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.data.model.UserDetails;
-import uk.gov.laa.ccms.soa.gateway.model.TransactionStatus;
 
 /**
  * Client class responsible for interacting with the ebs-api microservice to retrieve various data

--- a/src/main/java/uk/gov/laa/ccms/caab/client/SoaApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/SoaApiClient.java
@@ -163,30 +163,6 @@ public class SoaApiClient {
   }
 
   /**
-   * Fetches the transaction status for a client create transaction.
-   *
-   * @param transactionId         The transaction id for the client create transaction in soa.
-   * @param loginId               The login identifier for the user.
-   * @param userType              Type of the user (e.g., admin, user).
-   * @return A Mono wrapping the TransactionStatus.
-   */
-  public Mono<TransactionStatus> getClientStatus(
-      final String transactionId,
-      final String loginId,
-      final String userType) {
-    return soaApiWebClient
-        .get()
-        .uri("/clients/status/{transactionId}", transactionId)
-        .header(SOA_GATEWAY_USER_LOGIN_ID, loginId)
-        .header(SOA_GATEWAY_USER_ROLE, userType)
-        .retrieve()
-        .bodyToMono(TransactionStatus.class)
-        .onErrorResume(e -> soaApiClientErrorHandler.handleApiRetrieveError(
-            e, "client transaction status", "transaction id", transactionId));
-
-  }
-
-  /**
    * Creates a client based on a given client details.
    *
    * @param clientDetails         The client's details.

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/submission/ClientSubmissionsInProgressController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/submission/ClientSubmissionsInProgressController.java
@@ -21,8 +21,8 @@ import org.springframework.web.bind.annotation.SessionAttribute;
 import uk.gov.laa.ccms.caab.constants.SubmissionConstants;
 import uk.gov.laa.ccms.caab.model.BaseClientDetail;
 import uk.gov.laa.ccms.caab.service.ClientService;
+import uk.gov.laa.ccms.data.model.TransactionStatus;
 import uk.gov.laa.ccms.data.model.UserDetail;
-import uk.gov.laa.ccms.soa.gateway.model.TransactionStatus;
 
 /**
  * Controller for client creation submissions in progress.

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/submission/ClientSubmissionsInProgressController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/submission/ClientSubmissionsInProgressController.java
@@ -44,16 +44,13 @@ public class ClientSubmissionsInProgressController {
   @GetMapping("/submissions/client-create")
   public String clientCreateSubmission(
       @SessionAttribute(SUBMISSION_TRANSACTION_ID) final String transactionId,
-      @SessionAttribute(USER_DETAILS) final UserDetail user,
       final HttpSession session,
       final Model model) {
 
     model.addAttribute("submissionType", SUBMISSION_CREATE_CLIENT);
 
     final TransactionStatus clientStatus = clientService.getClientStatus(
-        transactionId,
-        user.getLoginId(),
-        user.getUserType()).block();
+        transactionId).block();
 
     if (clientStatus != null && StringUtils.hasText(clientStatus.getReferenceNumber())) {
       session.setAttribute(CLIENT_REFERENCE, clientStatus.getReferenceNumber());
@@ -84,9 +81,7 @@ public class ClientSubmissionsInProgressController {
     model.addAttribute("submissionType", SUBMISSION_UPDATE_CLIENT);
 
     final TransactionStatus clientStatus = clientService.getClientStatus(
-        transactionId,
-        user.getLoginId(),
-        user.getUserType()).block();
+        transactionId).block();
 
     if (clientStatus != null && StringUtils.hasText(clientStatus.getReferenceNumber())) {
       clientService.updateClientNames(

--- a/src/main/java/uk/gov/laa/ccms/caab/service/ClientService.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/service/ClientService.java
@@ -12,11 +12,11 @@ import uk.gov.laa.ccms.caab.client.SoaApiClient;
 import uk.gov.laa.ccms.caab.mapper.ClientDetailMapper;
 import uk.gov.laa.ccms.caab.model.BaseClientDetail;
 import uk.gov.laa.ccms.caab.util.ReflectionUtils;
+import uk.gov.laa.ccms.data.model.TransactionStatus;
 import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetail;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetails;
 import uk.gov.laa.ccms.soa.gateway.model.ClientTransactionResponse;
-import uk.gov.laa.ccms.soa.gateway.model.TransactionStatus;
 
 /**
  * Service class to handle Clients.

--- a/src/main/java/uk/gov/laa/ccms/caab/service/ClientService.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/service/ClientService.java
@@ -7,6 +7,7 @@ import reactor.core.publisher.Mono;
 import uk.gov.laa.ccms.caab.bean.ClientFlowFormData;
 import uk.gov.laa.ccms.caab.bean.ClientSearchCriteria;
 import uk.gov.laa.ccms.caab.client.CaabApiClient;
+import uk.gov.laa.ccms.caab.client.EbsApiClient;
 import uk.gov.laa.ccms.caab.client.SoaApiClient;
 import uk.gov.laa.ccms.caab.mapper.ClientDetailMapper;
 import uk.gov.laa.ccms.caab.model.BaseClientDetail;
@@ -29,6 +30,7 @@ public class ClientService {
   private final CaabApiClient caabApiClient;
 
   private final ClientDetailMapper clientDetailsMapper;
+  private final EbsApiClient ebsApiClient;
 
   /**
    * Searches and retrieves client details based on provided search criteria.
@@ -67,19 +69,15 @@ public class ClientService {
   }
 
   /**
-   * Fetches the transaction status for a client create transaction.
+   * Fetches the transaction status for a client transaction.
    *
-   * @param transactionId         The transaction id for the client create transaction in soa.
-   * @param loginId               The login identifier for the user.
-   * @param userType              Type of the user (e.g., admin, user).
+   * @param transactionId         The transaction id for the client transaction in soa.
    * @return A Mono wrapping the TransactionStatus.
    */
   public Mono<TransactionStatus> getClientStatus(
-      final String transactionId,
-      final String loginId,
-      final String userType) {
-    log.debug("SOA Client Status to get using transaction Id: {}", transactionId);
-    return soaApiClient.getClientStatus(transactionId, loginId, userType);
+      final String transactionId) {
+    log.debug("EBS Client Status to get using transaction Id: {}", transactionId);
+    return ebsApiClient.getClientStatus(transactionId);
   }
 
   /**

--- a/src/test/java/uk/gov/laa/ccms/caab/client/EbsApiClientTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/client/EbsApiClientTest.java
@@ -1610,8 +1610,6 @@ public class EbsApiClientTest {
     @DisplayName("Should return successfully")
     void getClientStatus_Successful() {
       String transactionId = "123";
-      String loginId = "user1";
-      String userType = "userType";
       String expectedUri = "/clients/status/{transactionId}";
 
       TransactionStatus mockTransactionStatus = new TransactionStatus();
@@ -1634,8 +1632,6 @@ public class EbsApiClientTest {
     @DisplayName("Should handle error")
     void getClientStatus_Error() {
       String transactionId = "123";
-      String loginId = "user1";
-      String userType = "userType";
       String expectedUri = "/clients/status/{transactionId}";
 
       when(webClientMock.get()).thenReturn(requestHeadersUriMock);

--- a/src/test/java/uk/gov/laa/ccms/caab/client/EbsApiClientTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/client/EbsApiClientTest.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,6 +53,7 @@ import uk.gov.laa.ccms.data.model.ScopeLimitationDetails;
 import uk.gov.laa.ccms.data.model.StageEndLookupDetail;
 import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.data.model.UserDetails;
+import uk.gov.laa.ccms.soa.gateway.model.TransactionStatus;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -79,1248 +81,1578 @@ public class EbsApiClientTest {
 
   ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
 
-  @Test
-  void getUser_returnData() {
-
-    final String loginId = "user1";
-    final String expectedUri = "/users/{loginId}";
-
-    final UserDetail mockUser = new UserDetail();
-    mockUser.setLoginId(loginId);
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(UserDetail.class)).thenReturn(Mono.just(mockUser));
-
-    final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(loginId);
-
-    StepVerifier.create(userDetailsMono)
-        .expectNextMatches(user -> user.getLoginId().equals(loginId))
-        .verifyComplete();
-  }
-
-  @Test
-  void getUser_notFound() {
-    final String loginId = "user1";
-    final String expectedUri = "/users/{loginId}";
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(UserDetail.class)).thenReturn(Mono.error(
-        new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
-
-    when(apiClientErrorHandler.handleApiRetrieveError(
-        any(), eq("User"), eq("login id"), eq(loginId))).thenReturn(Mono.empty());
-
-    final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(loginId);
-
-    StepVerifier.create(userDetailsMono)
-        .verifyComplete();
-  }
-
-  @Test
-  void getUserNotificationSummary_returnsData() {
-    final String loginId = "user1";
-    final String expectedUri = "/users/{loginId}/notifications/summary";
-
-    final NotificationSummary mockNotificationSummary = new NotificationSummary();
-    mockNotificationSummary.setNotifications(1);
-    mockNotificationSummary.setStandardActions(3);
-    mockNotificationSummary.setOverdueActions(2);
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(NotificationSummary.class)).thenReturn(
-        Mono.just(mockNotificationSummary));
-
-    final Mono<NotificationSummary> notificationSummary = ebsApiClient.getUserNotificationSummary(
-        loginId);
-
-    StepVerifier.create(notificationSummary)
-        .expectNextMatches(summary ->
-            summary.getNotifications().equals(1) &&
-                summary.getStandardActions().equals(3) &&
-                summary.getOverdueActions().equals(2)
-        )
-        .verifyComplete();
-  }
-
-  @Test
-  void getUserNotificationSummary_NotFound() {
-    final String loginId = "user1";
-    final String expectedUri = "/users/{loginId}/notifications/summary";
-
-    final NotificationSummary mockNotificationSummary = new NotificationSummary();
-    mockNotificationSummary.setNotifications(1);
-    mockNotificationSummary.setStandardActions(3);
-    mockNotificationSummary.setOverdueActions(2);
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(NotificationSummary.class)).thenReturn(
-        Mono.just(mockNotificationSummary));
-
-    final Mono<NotificationSummary> notificationSummary = ebsApiClient.getUserNotificationSummary(
-        loginId);
-
-    StepVerifier.create(notificationSummary)
-        .expectNextMatches(summary ->
-            summary.getNotifications().equals(1) &&
-                summary.getStandardActions().equals(3) &&
-                summary.getOverdueActions().equals(2)
-        )
-        .verifyComplete();
-  }
-
-  @Test
-  void getNotifications_successful() {
-    NotificationSearchCriteria criteria = new NotificationSearchCriteria();
-    criteria.setAssignedToUserId("testUserId");
-
-    criteria.setLoginId("testUserId");
-    criteria.setUserType("testUserType");
-    int page = 10, size = 10;
-    String expectedUri = String.format(
-        "/notifications?assigned-to-user-id=%s&include-closed=%s&page=%s&" +
-            "size=%s",
-        criteria.getAssignedToUserId(),
-        criteria.isIncludeClosed(),
-        page,
-        size);
-
-    ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-
-    Notifications notificationsObj = new Notifications();
-
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(Notifications.class)).thenReturn(
-        Mono.just(notificationsObj));
-    Mono<uk.gov.laa.ccms.data.model.Notifications> notificationsMono = ebsApiClient.getNotifications(
-        criteria, page,
-        size);
-
-    StepVerifier.create(notificationsMono)
-        .expectNextMatches(notifications -> notifications == notificationsObj)
-        .verifyComplete();
-    Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-    assertEquals(expectedUri, actualUri.toString());
-  }
-
-  @Test
-  void getNotifications_handlesError() {
-
-    NotificationSearchCriteria criteria = new NotificationSearchCriteria();
-    criteria.setAssignedToUserId("testUserId");
-    criteria.setLoginId("testUserId");
-    criteria.setUserType("testUserType");
-    int page = 10, size = 10;
-    String expectedUri = String.format(
-        "/notifications?assigned-to-user-id=%s&include-closed=%s&page=%s&" +
-            "size=%s",
-        criteria.getAssignedToUserId(),
-        criteria.isIncludeClosed(),
-        page,
-        size);
-
-    ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(Notifications.class)).thenReturn(Mono.error(
-        new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
-
-    when(
-        apiClientErrorHandler.handleApiRetrieveError(any(), eq("Notifications"), any())).thenReturn(
-        Mono.empty());
-
-    Mono<Notifications> notificationsMono =
-        ebsApiClient.getNotifications(criteria, page, size);
-
-    StepVerifier.create(notificationsMono)
-        .verifyComplete();
-    Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-    assertEquals(expectedUri, actualUri.toString());
-    assertEquals(expectedUri, actualUri.toString());
-  }
-
-  @Test
-  void getCommonValues_returnsData() {
-    final String type = "type1";
-    final String code = "code1";
-    final String descr = "desc1";
-    final String sort = "sort1";
-    final CommonLookupDetail commonValues = new CommonLookupDetail();
-
-    final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.just(commonValues));
-
-    final Mono<CommonLookupDetail> commonValuesMono = ebsApiClient.getCommonValues(type, code, descr, sort);
-
-    StepVerifier.create(commonValuesMono)
-        .expectNext(commonValues)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals(String.format("/lookup/common?size=1000&type=%s&code=%s&description=%s&sort=%s",
-            type, code, descr, sort), actualUri.toString());
-  }
-
-  @Test
-  void getCommonValues_notFound() {
-    final String type = "type1";
-    final String code = "code1";
-    final String descr = "desc1";
-    final String sort = "sort1";
-
-    final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.error(
-        new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
-
-    when(apiClientErrorHandler.handleApiRetrieveError(
-        any(), eq("Common values"), any())).thenReturn(Mono.empty());
-
-    final Mono<CommonLookupDetail> commonValuesMono = ebsApiClient.getCommonValues(
-        type, code, descr, sort);
-
-    StepVerifier.create(commonValuesMono)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals(String.format("/lookup/common?size=1000&type=%s&code=%s&description=%s&sort=%s",
-        type, code, descr, sort), actualUri.toString());
-  }
-
-  @Test
-  void getCaseStatusValuesCopyAllowed_returnsData() {
-    final CaseStatusLookupDetail caseStatusLookupDetail = new CaseStatusLookupDetail();
-
-    final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CaseStatusLookupDetail.class)).thenReturn(
-        Mono.just(caseStatusLookupDetail));
-
-    final Mono<CaseStatusLookupDetail> lookupDetailMono = ebsApiClient.getCaseStatusValues(true);
-
-    StepVerifier.create(lookupDetailMono)
-        .expectNext(caseStatusLookupDetail)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals("/lookup/case-status?size=1000&copy-allowed=true", actualUri.toString());
-  }
-
-  @Test
-  void getProvider_returnsData() {
-    final Integer providerId = 123;
-    final ProviderDetail providerDetail = new ProviderDetail();
-
-    final String expectedUri = "/providers/{providerId}";
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(expectedUri, String.valueOf(providerId))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(ProviderDetail.class)).thenReturn(Mono.just(providerDetail));
-
-    final Mono<ProviderDetail> providerDetailMono = ebsApiClient.getProvider(providerId);
-
-    StepVerifier.create(providerDetailMono)
-        .expectNext(providerDetail)
-        .verifyComplete();
-  }
-
-  @Test
-  void getPersonRelationshipsToCaseValues_returnsData() {
-    final RelationshipToCaseLookupDetail relationshipToCaseLookupDetail
-        = new RelationshipToCaseLookupDetail();
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(RelationshipToCaseLookupDetail.class))
-        .thenReturn(Mono.just(relationshipToCaseLookupDetail));
-
-    final Mono<RelationshipToCaseLookupDetail> relationshipToCaseLookupDetailMono =
-        ebsApiClient.getPersonRelationshipsToCaseValues();
-
-    StepVerifier.create(relationshipToCaseLookupDetailMono)
-        .expectNext(relationshipToCaseLookupDetail)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals("/lookup/person-to-case-relationships", actualUri.toString());
-  }
-
-  @Test
-  void getOrganisationRelationshipsToCaseValues_returnsData() {
-    final RelationshipToCaseLookupDetail relationshipToCaseLookupDetail
-        = new RelationshipToCaseLookupDetail();
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(RelationshipToCaseLookupDetail.class))
-        .thenReturn(Mono.just(relationshipToCaseLookupDetail));
-
-    final Mono<RelationshipToCaseLookupDetail> relationshipToCaseLookupDetailMono =
-        ebsApiClient.getOrganisationToCaseRelationshipValues(null, null);
-
-    StepVerifier.create(relationshipToCaseLookupDetailMono)
-        .expectNext(relationshipToCaseLookupDetail)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals("/lookup/organisation-to-case-relationships?size=1000", actualUri.toString());
-  }
-
-  @Test
-  void getAmendmentTypes_returnsData() {
-    final String applicationType = "appType1";
-    final AmendmentTypeLookupDetail amendmentTypeLookupDetail = new AmendmentTypeLookupDetail();
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(AmendmentTypeLookupDetail.class)).thenReturn(
-        Mono.just(amendmentTypeLookupDetail));
-
-    final Mono<AmendmentTypeLookupDetail> amendmentTypesMono =
-        ebsApiClient.getAmendmentTypes(applicationType);
-
-    StepVerifier.create(amendmentTypesMono)
-        .expectNext(amendmentTypeLookupDetail)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals("/lookup/amendment-types?size=1000&application-type=appType1", actualUri.toString());
-  }
-
-  @Test
-  void getAmendmentTypes_notFound() {
-    final String applicationType = "appType1";
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(AmendmentTypeLookupDetail.class)).thenReturn(Mono.error(
-        new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
-
-    when(apiClientErrorHandler.handleApiRetrieveError(any(), eq("Amendment types"), any())).thenReturn(Mono.empty());
-
-    final Mono<AmendmentTypeLookupDetail> amendmentTypesMono =
-        ebsApiClient.getAmendmentTypes(applicationType);
-
-    StepVerifier.create(amendmentTypesMono)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals("/lookup/amendment-types?size=1000&application-type=appType1", actualUri.toString());
-  }
-
-  @Test
-  void getCountries_returnsData() {
-    final CommonLookupDetail commonValues = new CommonLookupDetail();
-    // Set up your mock commonValues
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.just(commonValues));
-
-    final Mono<CommonLookupDetail> countriesMono = ebsApiClient.getCountries();
-
-    StepVerifier.create(countriesMono)
-        .expectNext(commonValues)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals("/lookup/countries?size=1000", actualUri.toString());
-  }
-
-  @Test
-  void getCountries_notFound() {
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.error(
-        new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
-
-    when(apiClientErrorHandler.handleApiRetrieveError(
-        any(),eq("Countries"), any())).thenReturn(Mono.empty());
-
-    final Mono<CommonLookupDetail> countriesMono = ebsApiClient.getCountries();
-
-    StepVerifier.create(countriesMono)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals("/lookup/countries?size=1000", actualUri.toString());
-  }
-
-  @Test
-  void getProceeding_returnsData() {
-    final String proceedingCode = "PROC1";
-    final ProceedingDetail proceedingDetail = new ProceedingDetail();
-
-    final String expectedUri = "/proceedings/{proceeding-code}";
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(expectedUri, proceedingCode)).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(ProceedingDetail.class)).thenReturn(Mono.just(proceedingDetail));
-
-    final Mono<ProceedingDetail> proceedingDetailMono = ebsApiClient.getProceeding(proceedingCode);
-
-    StepVerifier.create(proceedingDetailMono)
-        .expectNext(proceedingDetail)
-        .verifyComplete();
-  }
-  @Test
-  void getUsersForProvider_returnsData() {
-    // Mock some objects
-    final String username = "user1";
-    final String expectedUri = "/users?size=1000&provider-id=123";
-    final Integer providerId = 123;
-    final BaseUser mockUser = new BaseUser()
-        .username(username)
-        .userId(123);
-    final UserDetails mockDetails = new UserDetails()
-        .addContentItem(mockUser);
-
-    // Stubs
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(UserDetails.class)).thenReturn(Mono.just(mockDetails));
-
-    // Call the method
-    final Mono<UserDetails> userDetailsMono = ebsApiClient.getUsers(providerId);
-
-    // Assertions
-    StepVerifier.create(userDetailsMono)
-        .expectNext(mockDetails)
-        .verifyComplete();
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-    assertEquals(expectedUri, actualUri.toString());
+  @Nested
+  @DisplayName("getUser() Tests")
+  class GetUserTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getUser_returnData() {
+
+      final String loginId = "user1";
+      final String expectedUri = "/users/{loginId}";
+
+      final UserDetail mockUser = new UserDetail();
+      mockUser.setLoginId(loginId);
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(UserDetail.class)).thenReturn(Mono.just(mockUser));
+
+      final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(loginId);
+
+      StepVerifier.create(userDetailsMono)
+          .expectNextMatches(user -> user.getLoginId().equals(loginId))
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return not found")
+    void getUser_notFound() {
+      final String loginId = "user1";
+      final String expectedUri = "/users/{loginId}";
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(UserDetail.class)).thenReturn(Mono.error(
+          new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
+
+      when(apiClientErrorHandler.handleApiRetrieveError(
+          any(), eq("User"), eq("login id"), eq(loginId))).thenReturn(Mono.empty());
+
+      final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(loginId);
+
+      StepVerifier.create(userDetailsMono)
+          .verifyComplete();
+    }
 
   }
 
-  @Test
-  void getUsersForProvider_notFound() {
-    final Integer providerId = 123;
+  @Nested
+  @DisplayName("getUserNotificationSummary() Tests")
+  class GetUserNotificationSummaryTests {
 
-    final String expectedUri = "/users?size=1000&provider-id=123";
+    @Test
+    @DisplayName("Should return not found")
+    void getUserNotificationSummary_returnsData() {
+      final String loginId = "user1";
+      final String expectedUri = "/users/{loginId}/notifications/summary";
 
-    // Stubs
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(UserDetails.class)).thenReturn(Mono.error(
-        new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
+      final NotificationSummary mockNotificationSummary = new NotificationSummary();
+      mockNotificationSummary.setNotifications(1);
+      mockNotificationSummary.setStandardActions(3);
+      mockNotificationSummary.setOverdueActions(2);
 
-    when(apiClientErrorHandler.handleApiRetrieveError(any(), any(), any()))
-        .thenReturn(Mono.empty());
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(NotificationSummary.class)).thenReturn(
+          Mono.just(mockNotificationSummary));
 
-    final Mono<UserDetails> userDetailsMono = ebsApiClient.getUsers(providerId);
-    StepVerifier.create(userDetailsMono)
-        .verifyComplete();
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-    assertEquals(expectedUri, actualUri.toString());
+      final Mono<NotificationSummary> notificationSummary = ebsApiClient.getUserNotificationSummary(
+          loginId);
+
+      StepVerifier.create(notificationSummary)
+          .expectNextMatches(summary ->
+              summary.getNotifications().equals(1) &&
+                  summary.getStandardActions().equals(3) &&
+                  summary.getOverdueActions().equals(2)
+          )
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return data")
+    void getUserNotificationSummary_NotFound() {
+      final String loginId = "user1";
+      final String expectedUri = "/users/{loginId}/notifications/summary";
+
+      final NotificationSummary mockNotificationSummary = new NotificationSummary();
+      mockNotificationSummary.setNotifications(1);
+      mockNotificationSummary.setStandardActions(3);
+      mockNotificationSummary.setOverdueActions(2);
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(NotificationSummary.class)).thenReturn(
+          Mono.just(mockNotificationSummary));
+
+      final Mono<NotificationSummary> notificationSummary = ebsApiClient.getUserNotificationSummary(
+          loginId);
+
+      StepVerifier.create(notificationSummary)
+          .expectNextMatches(summary ->
+              summary.getNotifications().equals(1) &&
+                  summary.getStandardActions().equals(3) &&
+                  summary.getOverdueActions().equals(2)
+          )
+          .verifyComplete();
+    }
   }
 
-  @Test
-  void getScopeLimitations_returnsData() {
-    final uk.gov.laa.ccms.data.model.ScopeLimitationDetail scopeLimitationDetail =
-        new uk.gov.laa.ccms.data.model.ScopeLimitationDetail()
-        .scopeLimitations("scopeLimitations")
-        .categoryOfLaw("categoryOfLaw")
-        .matterType("matterType")
-        .proceedingCode("proceedingCode")
-        .levelOfService("levelOfService")
-        .defaultWording("defaultWording")
-        .stage(1)
-        .costLimitation(BigDecimal.TEN)
-        .emergencyCostLimitation(BigDecimal.TEN)
-        .nonStandardWordingRequired(Boolean.TRUE)
-        .emergencyScopeDefault(Boolean.TRUE)
-        .emergency(Boolean.TRUE)
-        .defaultCode(Boolean.TRUE)
-        .scopeDefault(Boolean.TRUE);
+  @Nested
+  @DisplayName("getNotifications() Tests")
+  class GetNotificationsTests {
 
-    final ScopeLimitationDetails expectedResponse = new ScopeLimitationDetails();
+    @Test
+    @DisplayName("Should return successfully")
+    void getNotifications_successful() {
+      NotificationSearchCriteria criteria = new NotificationSearchCriteria();
+      criteria.setAssignedToUserId("testUserId");
 
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(ScopeLimitationDetails.class)).thenReturn(
-        Mono.just(expectedResponse));
+      criteria.setLoginId("testUserId");
+      criteria.setUserType("testUserType");
+      int page = 10, size = 10;
+      String expectedUri = String.format(
+          "/notifications?assigned-to-user-id=%s&include-closed=%s&page=%s&" +
+              "size=%s",
+          criteria.getAssignedToUserId(),
+          criteria.isIncludeClosed(),
+          page,
+          size);
 
-    final Mono<ScopeLimitationDetails> resultsMono =
-        ebsApiClient.getScopeLimitations(scopeLimitationDetail);
+      ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
 
-    StepVerifier.create(resultsMono)
-        .expectNext(expectedResponse)
-        .verifyComplete();
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
 
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+      Notifications notificationsObj = new Notifications();
 
-    final String expectedUri = String.format(
-        "/scope-limitations?size=1000&scope-limitations=%s&category-of-law=%s&matter-type=%s"
-            + "&proceeding-code=%s&level-of-service=%s&default-wording=%s"
-            + "&stage=%s&cost-limitation=%s&emergency-cost-limitation=%s&non-standard-wording=%s"
-            + "&emergency-scope-default=%s&emergency=%s&default-code=%s&scope-default=%s",
-        scopeLimitationDetail.getScopeLimitations(),
-        scopeLimitationDetail.getCategoryOfLaw(),
-        scopeLimitationDetail.getMatterType(),
-        scopeLimitationDetail.getProceedingCode(),
-        scopeLimitationDetail.getLevelOfService(),
-        scopeLimitationDetail.getDefaultWording(),
-        scopeLimitationDetail.getStage(),
-        scopeLimitationDetail.getCostLimitation(),
-        scopeLimitationDetail.getEmergencyCostLimitation(),
-        scopeLimitationDetail.getNonStandardWordingRequired(),
-        scopeLimitationDetail.getEmergencyScopeDefault(),
-        scopeLimitationDetail.getEmergency(),
-        scopeLimitationDetail.getDefaultCode(),
-        scopeLimitationDetail.getScopeDefault());
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(Notifications.class)).thenReturn(
+          Mono.just(notificationsObj));
+      Mono<uk.gov.laa.ccms.data.model.Notifications> notificationsMono =
+          ebsApiClient.getNotifications(
+              criteria, page,
+              size);
 
-    // Assert the URI
-    assertEquals(expectedUri, actualUri.toString());
+      StepVerifier.create(notificationsMono)
+          .expectNextMatches(notifications -> notifications == notificationsObj)
+          .verifyComplete();
+      Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+      assertEquals(expectedUri, actualUri.toString());
+    }
+
+    @Test
+    @DisplayName("Should handle error")
+    void getNotifications_handlesError() {
+
+      NotificationSearchCriteria criteria = new NotificationSearchCriteria();
+      criteria.setAssignedToUserId("testUserId");
+      criteria.setLoginId("testUserId");
+      criteria.setUserType("testUserType");
+      int page = 10, size = 10;
+      String expectedUri = String.format(
+          "/notifications?assigned-to-user-id=%s&include-closed=%s&page=%s&" +
+              "size=%s",
+          criteria.getAssignedToUserId(),
+          criteria.isIncludeClosed(),
+          page,
+          size);
+
+      ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(Notifications.class)).thenReturn(Mono.error(
+          new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
+
+      when(
+          apiClientErrorHandler.handleApiRetrieveError(any(), eq("Notifications"),
+              any())).thenReturn(
+          Mono.empty());
+
+      Mono<Notifications> notificationsMono =
+          ebsApiClient.getNotifications(criteria, page, size);
+
+      StepVerifier.create(notificationsMono)
+          .verifyComplete();
+      Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+      assertEquals(expectedUri, actualUri.toString());
+      assertEquals(expectedUri, actualUri.toString());
+    }
+
   }
 
-  @Test
-  void getPriorAuthorityTypes_returnsData() {
-    final String code = "code1";
-    final Boolean valueRequired = Boolean.TRUE;
-
-    final PriorAuthorityTypeDetails priorAuthorityTypeDetails = new PriorAuthorityTypeDetails();
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(PriorAuthorityTypeDetails.class)).thenReturn(
-        Mono.just(priorAuthorityTypeDetails));
-
-    final Mono<PriorAuthorityTypeDetails> priorAuthorityTypeDetailsMono =
-        ebsApiClient.getPriorAuthorityTypes(code, valueRequired);
-
-    StepVerifier.create(priorAuthorityTypeDetailsMono)
-        .expectNext(priorAuthorityTypeDetails)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals(String.format("/prior-authority-types?size=1000&code=%s&value-required=%s",
-        code, valueRequired), actualUri.toString());
-  }
-
-  @Test
-  void getOutcomeResults_returnsData() {
-    final String proceedingCode = "code1";
-    final String outcomeResult = "or1";
-
-    final OutcomeResultLookupDetail outcomeResultLookupDetail = new OutcomeResultLookupDetail();
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(OutcomeResultLookupDetail.class)).thenReturn(
-        Mono.just(outcomeResultLookupDetail));
-
-    final Mono<OutcomeResultLookupDetail> outcomeResultLookupDetailMono =
-        ebsApiClient.getOutcomeResults(proceedingCode, outcomeResult);
-
-    StepVerifier.create(outcomeResultLookupDetailMono)
-        .expectNext(outcomeResultLookupDetail)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals(String.format("/lookup/outcome-results?size=1000&proceeding-code=%s&outcome-result=%s",
-        proceedingCode, outcomeResult), actualUri.toString());
-  }
-
-  @Test
-  void getStageEnds_returnsData() {
-    final String proceedingCode = "code1";
-    final String stageEnd = "stageEnd1";
-
-    final StageEndLookupDetail stageEndLookupDetail = new StageEndLookupDetail();
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(StageEndLookupDetail.class)).thenReturn(
-        Mono.just(stageEndLookupDetail));
-
-    final Mono<StageEndLookupDetail> stageEndLookupDetailMono =
-        ebsApiClient.getStageEnds(proceedingCode, stageEnd);
-
-    StepVerifier.create(stageEndLookupDetailMono)
-        .expectNext(stageEndLookupDetail)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals(String.format("/lookup/stage-ends?size=1000&proceeding-code=%s&stage-end=%s",
-        proceedingCode, stageEnd), actualUri.toString());
-  }
-
-  @Test
-  void getAwardTypes_returnsData() {
-    final String code = "code1";
-    final String awardType = "type1";
-
-    final AwardTypeLookupDetail awardTypeLookupDetail = new AwardTypeLookupDetail();
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(AwardTypeLookupDetail.class)).thenReturn(
-        Mono.just(awardTypeLookupDetail));
-
-    final Mono<AwardTypeLookupDetail> awardTypeLookupDetailMono =
-        ebsApiClient.getAwardTypes(code, awardType);
-
-    StepVerifier.create(awardTypeLookupDetailMono)
-        .expectNext(awardTypeLookupDetail)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    // Assert the URI
-    assertEquals("/lookup/award-types?size=1000&code=code1&award-type=type1", actualUri.toString());
-  }
-
-  @Test
-  void getCategoriesOfLaw_success() {
-    final String code = "code";
-    final String matterTypeDescription = "description";
-    final Boolean copyCostLimit = true;
-    final CategoryOfLawLookupDetail lookupDetail = new CategoryOfLawLookupDetail(); // Populate this as needed
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CategoryOfLawLookupDetail.class)).thenReturn(Mono.just(lookupDetail));
-
-    final Mono<CategoryOfLawLookupDetail> result = ebsApiClient.getCategoriesOfLaw(code, matterTypeDescription, copyCostLimit);
-
-    StepVerifier.create(result)
-        .expectNext(lookupDetail)
-        .verifyComplete();
-
-    verify(responseMock).bodyToMono(CategoryOfLawLookupDetail.class);
-  }
-
-  @Test
-  void getCategoriesOfLaw_errorHandling() {
-    final String code = "error_code";
-    final String matterTypeDescription = "error_description";
-    final Boolean copyCostLimit = false;
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CategoryOfLawLookupDetail.class)).thenReturn(Mono.error(new RuntimeException("Error")));
-
-    final Mono<CategoryOfLawLookupDetail> result = ebsApiClient.getCategoriesOfLaw(code, matterTypeDescription, copyCostLimit);
-
-    StepVerifier.create(result)
-        .expectError(RuntimeException.class)
-        .verify();
-
-    verify(responseMock).bodyToMono(CategoryOfLawLookupDetail.class);
-  }
-
-  @Test
-  void getPersonToCaseRelationships_success() {
-    final String code = "rel_code";
-    final String description = "rel_description";
-    final RelationshipToCaseLookupDetail lookupDetail = new RelationshipToCaseLookupDetail(); // Populate this as needed
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(RelationshipToCaseLookupDetail.class)).thenReturn(Mono.just(lookupDetail));
-
-    final Mono<RelationshipToCaseLookupDetail> result = ebsApiClient.getPersonToCaseRelationships(code, description);
-
-    StepVerifier.create(result)
-        .expectNext(lookupDetail)
-        .verifyComplete();
-
-    verify(responseMock).bodyToMono(RelationshipToCaseLookupDetail.class);
-  }
-
-  @Test
-  void getPersonToCaseRelationships_errorHandling() {
-    final String code = "error_rel_code";
-    final String description = "error_rel_description";
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(RelationshipToCaseLookupDetail.class)).thenReturn(Mono.error(new RuntimeException("Error")));
-
-    final Mono<RelationshipToCaseLookupDetail> result = ebsApiClient.getPersonToCaseRelationships(code, description);
-
-    StepVerifier.create(result)
-        .expectError(RuntimeException.class)
-        .verify();
-
-    verify(responseMock).bodyToMono(RelationshipToCaseLookupDetail.class);
-  }
-
-  @Test
-  void getProceedings_success() {
-    final ProceedingDetail searchCriteria = new ProceedingDetail();
-    searchCriteria.setCategoryOfLawCode("FAM");
-    searchCriteria.setMatterType("DOM");
-    searchCriteria.setAmendmentOnly(true);
-    final Boolean larScopeFlag = true;
-    final String applicationType = "NEW";
-    final Boolean isLead = true;
-
-    final ProceedingDetails mockDetails = new ProceedingDetails();
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(ProceedingDetails.class)).thenReturn(Mono.just(mockDetails));
-
-    final Mono<ProceedingDetails> result = ebsApiClient.getProceedings(searchCriteria, larScopeFlag, applicationType, isLead);
-
-    StepVerifier.create(result)
-        .expectNextMatches(details -> details.equals(mockDetails))
-        .verifyComplete();
-  }
-
-  @Test
-  void getProceedings_error() {
-    final ProceedingDetail searchCriteria = new ProceedingDetail();
-    final Boolean larScopeFlag = false;
-    final String applicationType = "MOD";
-    final Boolean isLead = false;
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(ProceedingDetails.class))
-        .thenReturn(Mono.error(new RuntimeException("Unexpected error")));
-
-    final Mono<ProceedingDetails> result = ebsApiClient.getProceedings(searchCriteria, larScopeFlag, applicationType, isLead);
-
-    StepVerifier.create(result)
-        .expectError(RuntimeException.class)
-        .verify();
-  }
-
-
-  @Test
-  void getClientInvolvementTypes_success() {
-    final String proceedingCode = "PROC123";
-    final ClientInvolvementTypeLookupDetail mockDetail = new ClientInvolvementTypeLookupDetail(); // Assume this is populated
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(ClientInvolvementTypeLookupDetail.class)).thenReturn(Mono.just(mockDetail));
-
-    final Mono<ClientInvolvementTypeLookupDetail> result = ebsApiClient.getClientInvolvementTypes(proceedingCode);
-
-    StepVerifier.create(result)
-        .expectNextMatches(detail -> detail.equals(mockDetail))
-        .verifyComplete();
-  }
-
-  @Test
-  void getClientInvolvementTypes_error() {
-    final String proceedingCode = "PROC123";
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(ClientInvolvementTypeLookupDetail.class))
-        .thenReturn(Mono.error(new RuntimeException("Unexpected error")));
-
-    final Mono<ClientInvolvementTypeLookupDetail> result = ebsApiClient.getClientInvolvementTypes(proceedingCode);
-
-    StepVerifier.create(result)
-        .expectError(RuntimeException.class)
-        .verify();
-  }
-
-  @Test
-  void getLevelOfServiceTypes_success() {
-    final String proceedingCode = "PROC123";
-    final String categoryOfLaw = "FAM";
-    final String matterType = "DOM";
-    final LevelOfServiceLookupDetail mockDetail = new LevelOfServiceLookupDetail(); // Assume this is populated
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(LevelOfServiceLookupDetail.class)).thenReturn(Mono.just(mockDetail));
-
-    final Mono<LevelOfServiceLookupDetail> result = ebsApiClient.getLevelOfServiceTypes(proceedingCode, categoryOfLaw, matterType);
-
-    StepVerifier.create(result)
-        .expectNextMatches(detail -> detail.equals(mockDetail))
-        .verifyComplete();
-  }
-
-  @Test
-  void getLevelOfServiceTypes_error() {
-    final String proceedingCode = "PROC404";
-    final String categoryOfLaw = "UNK";
-    final String matterType = "UNKNOWN";
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(LevelOfServiceLookupDetail.class))
-        .thenReturn(Mono.error(new RuntimeException("Unexpected error")));
-
-    final Mono<LevelOfServiceLookupDetail> result = ebsApiClient.getLevelOfServiceTypes(proceedingCode, categoryOfLaw, matterType);
-
-    StepVerifier.create(result)
-        .expectError(RuntimeException.class)
-        .verify();
-  }
-
-  @Test
-  void getEvidenceDocumentTypes_returnsData() {
-    final String type = "type1";
-    final String code = "code1";
-    final EvidenceDocumentTypeLookupDetail mockDetail = new EvidenceDocumentTypeLookupDetail();
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(EvidenceDocumentTypeLookupDetail.class)).thenReturn(Mono.just(mockDetail));
-
-    final Mono<EvidenceDocumentTypeLookupDetail> result = ebsApiClient.getEvidenceDocumentTypes(type, code);
-
-    StepVerifier.create(result)
-        .expectNextMatches(detail -> detail.equals(mockDetail))
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    assertEquals("/lookup/evidence-document-types?size=1000&type=type1&code=code1", actualUri.toString());
-  }
-
-  @Test
-  void getEvidenceDocumentTypes_notFound() {
-    final String type = "type1";
-    final String code = "code1";
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(EvidenceDocumentTypeLookupDetail.class)).thenReturn(Mono.error(
-        new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
-
-    when(apiClientErrorHandler.handleApiRetrieveError(any(), eq("Evidence document types"), any())).thenReturn(Mono.empty());
-
-    final Mono<EvidenceDocumentTypeLookupDetail> result = ebsApiClient.getEvidenceDocumentTypes(type, code);
-
-    StepVerifier.create(result)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    assertEquals("/lookup/evidence-document-types?size=1000&type=type1&code=code1", actualUri.toString());
-  }
-
-  @Test
-  void getAssessmentSummaryAttributes_returnsData() {
-    final String summaryType = "summary1";
-    final AssessmentSummaryEntityLookupDetail mockDetail = new AssessmentSummaryEntityLookupDetail();
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(AssessmentSummaryEntityLookupDetail.class)).thenReturn(Mono.just(mockDetail));
-
-    final Mono<AssessmentSummaryEntityLookupDetail> result = ebsApiClient.getAssessmentSummaryAttributes(summaryType);
-
-    StepVerifier.create(result)
-        .expectNextMatches(detail -> detail.equals(mockDetail))
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    assertEquals("/lookup/assessment-summary-attributes?size=1000&summary-type=summary1", actualUri.toString());
-  }
-
-  @Test
-  void getAssessmentSummaryAttributes_notFound() {
-    final String summaryType = "summary1";
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(AssessmentSummaryEntityLookupDetail.class)).thenReturn(Mono.error(
-        new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
-
-    when(apiClientErrorHandler.handleApiRetrieveError(any(), eq("Assessment summary attributes"), any())).thenReturn(Mono.empty());
-
-    final Mono<AssessmentSummaryEntityLookupDetail> result = ebsApiClient.getAssessmentSummaryAttributes(summaryType);
-
-    StepVerifier.create(result)
-        .verifyComplete();
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    assertEquals("/lookup/assessment-summary-attributes?size=1000&summary-type=summary1", actualUri.toString());
-  }
-
-  @Test
-  @DisplayName("getCommonValues(type, code, description) - success")
-  void getCommonValues_withTypeCodeDescription_success() {
-    final String type = "type1";
-    final String code = "code1";
-    final String description = "desc1";
-    final CommonLookupDetail mockDetail = new CommonLookupDetail(); // Assume this is populated
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.just(mockDetail));
-
-    final Mono<CommonLookupDetail> result = ebsApiClient.getCommonValues(type, code, description);
-
-    StepVerifier.create(result)
-        .expectNext(mockDetail)
-        .verifyComplete();
-
-    verify(responseMock).bodyToMono(CommonLookupDetail.class);
-  }
-
-  @Test
-  @DisplayName("getCommonValues(type, code, description) - error handling")
-  void getCommonValues_withTypeCodeDescription_errorHandling() {
-    final String type = "type1";
-    final String code = "code1";
-    final String description = "desc1";
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.error(new RuntimeException("Error")));
-
-    final Mono<CommonLookupDetail> result = ebsApiClient.getCommonValues(type, code, description);
-
-    StepVerifier.create(result)
-        .expectError(RuntimeException.class)
-        .verify();
-
-    verify(responseMock).bodyToMono(CommonLookupDetail.class);
-  }
-
-  @Test
-  @DisplayName("getCommonValues(type, code) - success")
-  void getCommonValues_withTypeCode_success() {
-    final String type = "type1";
-    final String code = "code1";
-    final CommonLookupDetail mockDetail = new CommonLookupDetail(); // Assume this is populated
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.just(mockDetail));
-
-    final Mono<CommonLookupDetail> result = ebsApiClient.getCommonValues(type, code);
-
-    StepVerifier.create(result)
-        .expectNext(mockDetail)
-        .verifyComplete();
-
-    verify(responseMock).bodyToMono(CommonLookupDetail.class);
-  }
-
-  @Test
-  @DisplayName("getCommonValues(type) - success")
-  void getCommonValues_withType_success() {
-    final String type = "type1";
-    final CommonLookupDetail mockDetail = new CommonLookupDetail(); // Assume this is populated
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.just(mockDetail));
-
-    final Mono<CommonLookupDetail> result = ebsApiClient.getCommonValues(type);
-
-    StepVerifier.create(result)
-        .expectNext(mockDetail)
-        .verifyComplete();
-
-    verify(responseMock).bodyToMono(CommonLookupDetail.class);
-  }
-
-  @Test
-  @DisplayName("getMatterTypes(categoryOfLaw) - success")
-  void getMatterTypes_withCategoryOfLaw_success() {
-    final String categoryOfLaw = "LAW1";
-    final MatterTypeLookupDetail mockDetail = new MatterTypeLookupDetail(); // Assume this is populated
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(MatterTypeLookupDetail.class)).thenReturn(Mono.just(mockDetail));
-
-    final Mono<MatterTypeLookupDetail> result = ebsApiClient.getMatterTypes(categoryOfLaw);
-
-    StepVerifier.create(result)
-        .expectNext(mockDetail)
-        .verifyComplete();
-
-    verify(responseMock).bodyToMono(MatterTypeLookupDetail.class);
-  }
-
-  @Test
-  @DisplayName("getMatterTypes(categoryOfLaw) - error handling")
-  void getMatterTypes_withCategoryOfLaw_errorHandling() {
-    final String categoryOfLaw = "LAW1";
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(MatterTypeLookupDetail.class)).thenReturn(Mono.error(new RuntimeException("Error")));
-
-    final Mono<MatterTypeLookupDetail> result = ebsApiClient.getMatterTypes(categoryOfLaw);
-
-    StepVerifier.create(result)
-        .expectError(RuntimeException.class)
-        .verify();
-
-    verify(responseMock).bodyToMono(MatterTypeLookupDetail.class);
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-      "DECLARATION_TYPE, BILL_TYPE, /lookup/declarations?size=1000&type=DECLARATION_TYPE&billType=BILL_TYPE",
-      "DECLARATION_TYPE, , /lookup/declarations?size=1000&type=DECLARATION_TYPE",
-      ", BILL_TYPE, /lookup/declarations?size=1000&billType=BILL_TYPE",
-      ", , /lookup/declarations?size=1000"
-  })
-  @DisplayName("getDeclarations parameterized test")
-  void testGetDeclarations(final String type, final String billType, final String expectedUri) {
-    final DeclarationLookupDetail mockDeclarationDetail = new DeclarationLookupDetail();
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(DeclarationLookupDetail.class)).thenReturn(Mono.just(mockDeclarationDetail));
-
-    final Mono<DeclarationLookupDetail> result = ebsApiClient.getDeclarations(type, billType);
-
-    StepVerifier.create(result)
-        .expectNext(mockDeclarationDetail)
-        .verifyComplete();
-
-    final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
-    verify(requestHeadersUriMock).uri(uriCaptor.capture());
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    assertEquals(expectedUri, actualUri.toString());
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-      "DECLARATION_TYPE, BILL_TYPE, /lookup/declarations?size=1000&type=DECLARATION_TYPE&billType=BILL_TYPE",
-      "DECLARATION_TYPE, , /lookup/declarations?size=1000&type=DECLARATION_TYPE"
-  })
-  @DisplayName("getDeclarations handles errors in a parameterized test")
-  void testGetDeclarations_handlesError(final String type, final String billType, final String expectedUri) {
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(DeclarationLookupDetail.class)).thenReturn(Mono.error(new RuntimeException("Error")));
-
-    when(apiClientErrorHandler.handleApiRetrieveError(any(), eq("Declarations"), any())).thenReturn(Mono.empty());
-
-    final Mono<DeclarationLookupDetail> result = ebsApiClient.getDeclarations(type, billType);
-
-    StepVerifier.create(result)
-        .verifyComplete();
-
-    final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
-    verify(requestHeadersUriMock).uri(uriCaptor.capture());
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    assertEquals(expectedUri, actualUri.toString());
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-      "true, type1, /lookup/provider-request-types?size=1000&is-case-related=true&type=type1",
-      "true, , /lookup/provider-request-types?size=1000&is-case-related=true",
-      ", type1, /lookup/provider-request-types?size=1000&type=type1",
-      ", , /lookup/provider-request-types?size=1000"
-  })
-  @DisplayName("getProviderRequestTypes parameterized test")
-  void testGetProviderRequestTypes(final Boolean isCaseRelated, final String type, final String expectedUri) {
-    final ProviderRequestTypeLookupDetail mockDetail = new ProviderRequestTypeLookupDetail();
-
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(ProviderRequestTypeLookupDetail.class)).thenReturn(Mono.just(mockDetail));
-
-    final Mono<ProviderRequestTypeLookupDetail> result = ebsApiClient.getProviderRequestTypes(isCaseRelated, type);
-
-    StepVerifier.create(result)
-        .expectNext(mockDetail)
-        .verifyComplete();
-
-    final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
-    verify(requestHeadersUriMock).uri(uriCaptor.capture());
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    assertEquals(expectedUri, actualUri.toString());
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-      "true, type1, /lookup/provider-request-types?size=1000&is-case-related=true&type=type1",
-      "true, , /lookup/provider-request-types?size=1000&is-case-related=true"
-  })
-  @DisplayName("getProviderRequestTypes handles errors in a parameterized test")
-  void testGetProviderRequestTypes_handlesError(final Boolean isCaseRelated, final String type, final String expectedUri) {
-    when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(ProviderRequestTypeLookupDetail.class)).thenReturn(Mono.error(new RuntimeException("Error")));
-
-    when(apiClientErrorHandler.handleApiRetrieveError(any(), eq("Provider request types"), any())).thenReturn(Mono.empty());
-
-    final Mono<ProviderRequestTypeLookupDetail> result = ebsApiClient.getProviderRequestTypes(isCaseRelated, type);
-
-    StepVerifier.create(result)
-        .verifyComplete();
-
-    final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(Function.class);
-    verify(requestHeadersUriMock).uri(uriCaptor.capture());
-
-    final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
-    final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
-
-    assertEquals(expectedUri, actualUri.toString());
-  }
-
-
-  @Test
-  @DisplayName("postAllocateNextCaseReference creates case reference")
-  void testPostAllocateNextCaseReference_createsCaseReference() {
-    when(webClientMock.post()).thenReturn(requestBodyUriMock);
-    when(requestBodyUriMock.uri("/case-reference")).thenReturn(requestBodySpec);
-    when(requestBodySpec.retrieve()).thenReturn(responseMock);
-    CaseReferenceSummary caseReferenceSummary = new CaseReferenceSummary().caseReferenceNumber(
-        "123");
-    when(responseMock.bodyToMono(CaseReferenceSummary.class)).thenReturn(
-        Mono.just(caseReferenceSummary));
-
-    final Mono<CaseReferenceSummary> result = ebsApiClient.postAllocateNextCaseReference();
-
-    StepVerifier.create(result)
-        .expectNext(caseReferenceSummary)
-        .verifyComplete();
-
-    verify(responseMock).bodyToMono(CaseReferenceSummary.class);
-  }
-
-  @Test
-  @DisplayName("postAllocateNextCaseReference handles errors")
-  void testPostAllocateNextCaseReference_handlesError() {
-    when(webClientMock.post()).thenReturn(requestBodyUriMock);
-    when(requestBodyUriMock.uri("/case-reference")).thenReturn(requestBodySpec);
-    when(requestBodySpec.retrieve()).thenReturn(responseMock);
-    CaseReferenceSummary caseReferenceSummary = new CaseReferenceSummary().caseReferenceNumber(
-        "123");
-    when(responseMock.bodyToMono(CaseReferenceSummary.class))
-        .thenReturn(Mono.error(
+  @Nested
+  @DisplayName("getCommonValues() Tests")
+  class GetCommonValuesTests {
+
+    @Nested
+    @DisplayName("getCommonValues(type,code,descr,sort)")
+    class TypeCodeDescrSort {
+
+      @Test
+      @DisplayName("Should return data")
+      void getCommonValues_returnsData() {
+        final String type = "type1";
+        final String code = "code1";
+        final String descr = "desc1";
+        final String sort = "sort1";
+        final CommonLookupDetail commonValues = new CommonLookupDetail();
+
+        final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(
+            Function.class);
+
+        when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+        when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+        when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+        when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.just(commonValues));
+
+        final Mono<CommonLookupDetail> commonValuesMono = ebsApiClient.getCommonValues(type, code,
+            descr, sort);
+
+        StepVerifier.create(commonValuesMono)
+            .expectNext(commonValues)
+            .verifyComplete();
+
+        final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+        final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+        // Assert the URI
+        assertEquals(
+            String.format("/lookup/common?size=1000&type=%s&code=%s&description=%s&sort=%s",
+                type, code, descr, sort), actualUri.toString());
+      }
+
+      @Test
+      @DisplayName("Should return not found")
+      void getCommonValues_notFound() {
+        final String type = "type1";
+        final String code = "code1";
+        final String descr = "desc1";
+        final String sort = "sort1";
+
+        final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(
+            Function.class);
+
+        when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+        when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+        when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+        when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.error(
             new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
 
-    when(apiClientErrorHandler.handleApiRetrieveError(any(), eq("case reference"),
-        any())).thenReturn(Mono.empty());
+        when(apiClientErrorHandler.handleApiRetrieveError(
+            any(), eq("Common values"), any())).thenReturn(Mono.empty());
 
-    final Mono<CaseReferenceSummary> result = ebsApiClient.postAllocateNextCaseReference();
+        final Mono<CommonLookupDetail> commonValuesMono = ebsApiClient.getCommonValues(
+            type, code, descr, sort);
 
-    StepVerifier.create(result)
-        .verifyComplete();
+        StepVerifier.create(commonValuesMono)
+            .verifyComplete();
 
-    verify(responseMock).bodyToMono(CaseReferenceSummary.class);
+        final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+        final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+        // Assert the URI
+        assertEquals(
+            String.format("/lookup/common?size=1000&type=%s&code=%s&description=%s&sort=%s",
+                type, code, descr, sort), actualUri.toString());
+      }
+    }
+
+    @Nested
+    @DisplayName("getCommonValues(type,code,descr)")
+    class TypeCodeDescr {
+
+      @Test
+      @DisplayName("Should return success")
+      void getCommonValues_withTypeCodeDescription_success() {
+        final String type = "type1";
+        final String code = "code1";
+        final String description = "desc1";
+        final CommonLookupDetail mockDetail = new CommonLookupDetail(); // Assume this is populated
+
+        when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+        when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+        when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+        when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.just(mockDetail));
+
+        final Mono<CommonLookupDetail> result = ebsApiClient.getCommonValues(type, code,
+            description);
+
+        StepVerifier.create(result)
+            .expectNext(mockDetail)
+            .verifyComplete();
+
+        verify(responseMock).bodyToMono(CommonLookupDetail.class);
+      }
+
+      @Test
+      @DisplayName("Should handle error")
+      void getCommonValues_withTypeCodeDescription_errorHandling() {
+        final String type = "type1";
+        final String code = "code1";
+        final String description = "desc1";
+
+        when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+        when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+        when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+        when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(
+            Mono.error(new RuntimeException("Error")));
+
+        final Mono<CommonLookupDetail> result = ebsApiClient.getCommonValues(type, code,
+            description);
+
+        StepVerifier.create(result)
+            .expectError(RuntimeException.class)
+            .verify();
+
+        verify(responseMock).bodyToMono(CommonLookupDetail.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("getCommonValues(type,code)")
+    class TypeCode {
+      @Test
+      @DisplayName("Should return success")
+      void getCommonValues_withTypeCode_success() {
+        final String type = "type1";
+        final String code = "code1";
+        final CommonLookupDetail mockDetail = new CommonLookupDetail(); // Assume this is populated
+
+        when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+        when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+        when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+        when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.just(mockDetail));
+
+        final Mono<CommonLookupDetail> result = ebsApiClient.getCommonValues(type, code);
+
+        StepVerifier.create(result)
+            .expectNext(mockDetail)
+            .verifyComplete();
+
+        verify(responseMock).bodyToMono(CommonLookupDetail.class);
+      }
+    }
+
+    @Nested
+    @DisplayName("getCommonValues(type)")
+    class Type {
+
+      @Test
+      @DisplayName("Should return success")
+      void getCommonValues_withType_success() {
+        final String type = "type1";
+        final CommonLookupDetail mockDetail = new CommonLookupDetail(); // Assume this is populated
+
+        when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+        when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+        when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+        when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.just(mockDetail));
+
+        final Mono<CommonLookupDetail> result = ebsApiClient.getCommonValues(type);
+
+        StepVerifier.create(result)
+            .expectNext(mockDetail)
+            .verifyComplete();
+
+        verify(responseMock).bodyToMono(CommonLookupDetail.class);
+      }
+    }
   }
 
+  @Nested
+  @DisplayName("getCaseStatusValues() Tests")
+  class GetCaseStatusValuesTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getCaseStatusValuesCopyAllowed_returnsData() {
+      final CaseStatusLookupDetail caseStatusLookupDetail = new CaseStatusLookupDetail();
+
+      final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(
+          Function.class);
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(CaseStatusLookupDetail.class)).thenReturn(
+          Mono.just(caseStatusLookupDetail));
+
+      final Mono<CaseStatusLookupDetail> lookupDetailMono = ebsApiClient.getCaseStatusValues(true);
+
+      StepVerifier.create(lookupDetailMono)
+          .expectNext(caseStatusLookupDetail)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      // Assert the URI
+      assertEquals("/lookup/case-status?size=1000&copy-allowed=true", actualUri.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("getProvider() Tests")
+  class GetProviderTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getProvider_returnsData() {
+      final Integer providerId = 123;
+      final ProviderDetail providerDetail = new ProviderDetail();
+
+      final String expectedUri = "/providers/{providerId}";
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(expectedUri, String.valueOf(providerId))).thenReturn(
+          requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(ProviderDetail.class)).thenReturn(Mono.just(providerDetail));
+
+      final Mono<ProviderDetail> providerDetailMono = ebsApiClient.getProvider(providerId);
+
+      StepVerifier.create(providerDetailMono)
+          .expectNext(providerDetail)
+          .verifyComplete();
+    }
+  }
+
+  @Nested
+  @DisplayName("getPersonRelationshipsToCaseValues() Tests")
+  class GetPersonRelationshipsToCaseValuesTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getPersonRelationshipsToCaseValues_returnsData() {
+      final RelationshipToCaseLookupDetail relationshipToCaseLookupDetail
+          = new RelationshipToCaseLookupDetail();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(RelationshipToCaseLookupDetail.class))
+          .thenReturn(Mono.just(relationshipToCaseLookupDetail));
+
+      final Mono<RelationshipToCaseLookupDetail> relationshipToCaseLookupDetailMono =
+          ebsApiClient.getPersonRelationshipsToCaseValues();
+
+      StepVerifier.create(relationshipToCaseLookupDetailMono)
+          .expectNext(relationshipToCaseLookupDetail)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      // Assert the URI
+      assertEquals("/lookup/person-to-case-relationships", actualUri.toString());
+    }
+
+  }
+
+  @Nested
+  @DisplayName("getPersonRelationshipsToCaseValues() Tests")
+  class GetOrganisationToCaseRelationshipValuesTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getOrganisationRelationshipsToCaseValues_returnsData() {
+      final RelationshipToCaseLookupDetail relationshipToCaseLookupDetail
+          = new RelationshipToCaseLookupDetail();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(RelationshipToCaseLookupDetail.class))
+          .thenReturn(Mono.just(relationshipToCaseLookupDetail));
+
+      final Mono<RelationshipToCaseLookupDetail> relationshipToCaseLookupDetailMono =
+          ebsApiClient.getOrganisationToCaseRelationshipValues(null, null);
+
+      StepVerifier.create(relationshipToCaseLookupDetailMono)
+          .expectNext(relationshipToCaseLookupDetail)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      // Assert the URI
+      assertEquals("/lookup/organisation-to-case-relationships?size=1000", actualUri.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("getAmendmentTypes() Tests")
+  class GetAmendmentTypesTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getAmendmentTypes_returnsData() {
+      final String applicationType = "appType1";
+      final AmendmentTypeLookupDetail amendmentTypeLookupDetail = new AmendmentTypeLookupDetail();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(AmendmentTypeLookupDetail.class)).thenReturn(
+          Mono.just(amendmentTypeLookupDetail));
+
+      final Mono<AmendmentTypeLookupDetail> amendmentTypesMono =
+          ebsApiClient.getAmendmentTypes(applicationType);
+
+      StepVerifier.create(amendmentTypesMono)
+          .expectNext(amendmentTypeLookupDetail)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      // Assert the URI
+      assertEquals("/lookup/amendment-types?size=1000&application-type=appType1",
+          actualUri.toString());
+    }
+
+    @Test
+    @DisplayName("Should return not found")
+    void getAmendmentTypes_notFound() {
+      final String applicationType = "appType1";
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(AmendmentTypeLookupDetail.class)).thenReturn(Mono.error(
+          new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
+
+      when(apiClientErrorHandler.handleApiRetrieveError(any(), eq("Amendment types"),
+          any())).thenReturn(Mono.empty());
+
+      final Mono<AmendmentTypeLookupDetail> amendmentTypesMono =
+          ebsApiClient.getAmendmentTypes(applicationType);
+
+      StepVerifier.create(amendmentTypesMono)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      // Assert the URI
+      assertEquals("/lookup/amendment-types?size=1000&application-type=appType1",
+          actualUri.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("getCountries() Tests")
+  class GetCountriesTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getCountries_returnsData() {
+      final CommonLookupDetail commonValues = new CommonLookupDetail();
+      // Set up your mock commonValues
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.just(commonValues));
+
+      final Mono<CommonLookupDetail> countriesMono = ebsApiClient.getCountries();
+
+      StepVerifier.create(countriesMono)
+          .expectNext(commonValues)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      // Assert the URI
+      assertEquals("/lookup/countries?size=1000", actualUri.toString());
+    }
+
+    @Test
+    @DisplayName("Should return not found")
+    void getCountries_notFound() {
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(CommonLookupDetail.class)).thenReturn(Mono.error(
+          new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
+
+      when(apiClientErrorHandler.handleApiRetrieveError(
+          any(), eq("Countries"), any())).thenReturn(Mono.empty());
+
+      final Mono<CommonLookupDetail> countriesMono = ebsApiClient.getCountries();
+
+      StepVerifier.create(countriesMono)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      // Assert the URI
+      assertEquals("/lookup/countries?size=1000", actualUri.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("getProceeding() Tests")
+  class GetProceedingTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getProceeding_returnsData() {
+      final String proceedingCode = "PROC1";
+      final ProceedingDetail proceedingDetail = new ProceedingDetail();
+
+      final String expectedUri = "/proceedings/{proceeding-code}";
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(expectedUri, proceedingCode)).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(ProceedingDetail.class)).thenReturn(Mono.just(proceedingDetail));
+
+      final Mono<ProceedingDetail> proceedingDetailMono = ebsApiClient.getProceeding(
+          proceedingCode);
+
+      StepVerifier.create(proceedingDetailMono)
+          .expectNext(proceedingDetail)
+          .verifyComplete();
+    }
+  }
+
+  @Nested
+  @DisplayName("getUsers() Tests")
+  class GetUsersTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getUsersForProvider_returnsData() {
+      // Mock some objects
+      final String username = "user1";
+      final String expectedUri = "/users?size=1000&provider-id=123";
+      final Integer providerId = 123;
+      final BaseUser mockUser = new BaseUser()
+          .username(username)
+          .userId(123);
+      final UserDetails mockDetails = new UserDetails()
+          .addContentItem(mockUser);
+
+      // Stubs
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(UserDetails.class)).thenReturn(Mono.just(mockDetails));
+
+      // Call the method
+      final Mono<UserDetails> userDetailsMono = ebsApiClient.getUsers(providerId);
+
+      // Assertions
+      StepVerifier.create(userDetailsMono)
+          .expectNext(mockDetails)
+          .verifyComplete();
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+      assertEquals(expectedUri, actualUri.toString());
+
+    }
+
+    @Test
+    @DisplayName("Should return not found")
+    void getUsersForProvider_notFound() {
+      final Integer providerId = 123;
+
+      final String expectedUri = "/users?size=1000&provider-id=123";
+
+      // Stubs
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(UserDetails.class)).thenReturn(Mono.error(
+          new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
+
+      when(apiClientErrorHandler.handleApiRetrieveError(any(), any(), any()))
+          .thenReturn(Mono.empty());
+
+      final Mono<UserDetails> userDetailsMono = ebsApiClient.getUsers(providerId);
+      StepVerifier.create(userDetailsMono)
+          .verifyComplete();
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+      assertEquals(expectedUri, actualUri.toString());
+    }
+
+  }
+
+  @Nested
+  @DisplayName("getScopeLimitations() Tests")
+  class GetScopeLimitationsTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getScopeLimitations_returnsData() {
+      final uk.gov.laa.ccms.data.model.ScopeLimitationDetail scopeLimitationDetail =
+          new uk.gov.laa.ccms.data.model.ScopeLimitationDetail()
+              .scopeLimitations("scopeLimitations")
+              .categoryOfLaw("categoryOfLaw")
+              .matterType("matterType")
+              .proceedingCode("proceedingCode")
+              .levelOfService("levelOfService")
+              .defaultWording("defaultWording")
+              .stage(1)
+              .costLimitation(BigDecimal.TEN)
+              .emergencyCostLimitation(BigDecimal.TEN)
+              .nonStandardWordingRequired(Boolean.TRUE)
+              .emergencyScopeDefault(Boolean.TRUE)
+              .emergency(Boolean.TRUE)
+              .defaultCode(Boolean.TRUE)
+              .scopeDefault(Boolean.TRUE);
+
+      final ScopeLimitationDetails expectedResponse = new ScopeLimitationDetails();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(ScopeLimitationDetails.class)).thenReturn(
+          Mono.just(expectedResponse));
+
+      final Mono<ScopeLimitationDetails> resultsMono =
+          ebsApiClient.getScopeLimitations(scopeLimitationDetail);
+
+      StepVerifier.create(resultsMono)
+          .expectNext(expectedResponse)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      final String expectedUri = String.format(
+          "/scope-limitations?size=1000&scope-limitations=%s&category-of-law=%s&matter-type=%s"
+              + "&proceeding-code=%s&level-of-service=%s&default-wording=%s"
+              + "&stage=%s&cost-limitation=%s&emergency-cost-limitation=%s&non-standard-wording=%s"
+              + "&emergency-scope-default=%s&emergency=%s&default-code=%s&scope-default=%s",
+          scopeLimitationDetail.getScopeLimitations(),
+          scopeLimitationDetail.getCategoryOfLaw(),
+          scopeLimitationDetail.getMatterType(),
+          scopeLimitationDetail.getProceedingCode(),
+          scopeLimitationDetail.getLevelOfService(),
+          scopeLimitationDetail.getDefaultWording(),
+          scopeLimitationDetail.getStage(),
+          scopeLimitationDetail.getCostLimitation(),
+          scopeLimitationDetail.getEmergencyCostLimitation(),
+          scopeLimitationDetail.getNonStandardWordingRequired(),
+          scopeLimitationDetail.getEmergencyScopeDefault(),
+          scopeLimitationDetail.getEmergency(),
+          scopeLimitationDetail.getDefaultCode(),
+          scopeLimitationDetail.getScopeDefault());
+
+      // Assert the URI
+      assertEquals(expectedUri, actualUri.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("getPriorAuthorityTypes() Tests")
+  class GetPriorAuthorityTypesTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getPriorAuthorityTypes_returnsData() {
+      final String code = "code1";
+      final Boolean valueRequired = Boolean.TRUE;
+
+      final PriorAuthorityTypeDetails priorAuthorityTypeDetails = new PriorAuthorityTypeDetails();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(PriorAuthorityTypeDetails.class)).thenReturn(
+          Mono.just(priorAuthorityTypeDetails));
+
+      final Mono<PriorAuthorityTypeDetails> priorAuthorityTypeDetailsMono =
+          ebsApiClient.getPriorAuthorityTypes(code, valueRequired);
+
+      StepVerifier.create(priorAuthorityTypeDetailsMono)
+          .expectNext(priorAuthorityTypeDetails)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      // Assert the URI
+      assertEquals(String.format("/prior-authority-types?size=1000&code=%s&value-required=%s",
+          code, valueRequired), actualUri.toString());
+    }
+
+  }
+
+  @Nested
+  @DisplayName("getOutcomeResults() Tests")
+  class GetOutcomeResults {
+
+    @Test
+    @DisplayName("Should return data")
+    void getOutcomeResults_returnsData() {
+      final String proceedingCode = "code1";
+      final String outcomeResult = "or1";
+
+      final OutcomeResultLookupDetail outcomeResultLookupDetail = new OutcomeResultLookupDetail();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(OutcomeResultLookupDetail.class)).thenReturn(
+          Mono.just(outcomeResultLookupDetail));
+
+      final Mono<OutcomeResultLookupDetail> outcomeResultLookupDetailMono =
+          ebsApiClient.getOutcomeResults(proceedingCode, outcomeResult);
+
+      StepVerifier.create(outcomeResultLookupDetailMono)
+          .expectNext(outcomeResultLookupDetail)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      // Assert the URI
+      assertEquals(
+          String.format("/lookup/outcome-results?size=1000&proceeding-code=%s&outcome-result=%s",
+              proceedingCode, outcomeResult), actualUri.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("getStageEnds() Tests")
+  class GetStageEndsTests {
+
+    @Test
+    void getStageEnds_returnsData() {
+      final String proceedingCode = "code1";
+      final String stageEnd = "stageEnd1";
+
+      final StageEndLookupDetail stageEndLookupDetail = new StageEndLookupDetail();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(StageEndLookupDetail.class)).thenReturn(
+          Mono.just(stageEndLookupDetail));
+
+      final Mono<StageEndLookupDetail> stageEndLookupDetailMono =
+          ebsApiClient.getStageEnds(proceedingCode, stageEnd);
+
+      StepVerifier.create(stageEndLookupDetailMono)
+          .expectNext(stageEndLookupDetail)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      // Assert the URI
+      assertEquals(String.format("/lookup/stage-ends?size=1000&proceeding-code=%s&stage-end=%s",
+          proceedingCode, stageEnd), actualUri.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("getAwardTypes() Tests")
+  class GetAwardTypesTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getAwardTypes_returnsData() {
+      final String code = "code1";
+      final String awardType = "type1";
+
+      final AwardTypeLookupDetail awardTypeLookupDetail = new AwardTypeLookupDetail();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(AwardTypeLookupDetail.class)).thenReturn(
+          Mono.just(awardTypeLookupDetail));
+
+      final Mono<AwardTypeLookupDetail> awardTypeLookupDetailMono =
+          ebsApiClient.getAwardTypes(code, awardType);
+
+      StepVerifier.create(awardTypeLookupDetailMono)
+          .expectNext(awardTypeLookupDetail)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      // Assert the URI
+      assertEquals("/lookup/award-types?size=1000&code=code1&award-type=type1",
+          actualUri.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("getCategoriesOfLaw() Tests")
+  class GetCategoriesOfLawTests {
+
+    @Test
+    @DisplayName("Should return success")
+    void getCategoriesOfLaw_success() {
+      final String code = "code";
+      final String matterTypeDescription = "description";
+      final Boolean copyCostLimit = true;
+      final CategoryOfLawLookupDetail lookupDetail = new CategoryOfLawLookupDetail(); // Populate
+      // this as needed
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(CategoryOfLawLookupDetail.class)).thenReturn(
+          Mono.just(lookupDetail));
+
+      final Mono<CategoryOfLawLookupDetail> result = ebsApiClient.getCategoriesOfLaw(code,
+          matterTypeDescription, copyCostLimit);
+
+      StepVerifier.create(result)
+          .expectNext(lookupDetail)
+          .verifyComplete();
+
+      verify(responseMock).bodyToMono(CategoryOfLawLookupDetail.class);
+    }
+
+    @Test
+    @DisplayName("Should handle error")
+    void getCategoriesOfLaw_errorHandling() {
+      final String code = "error_code";
+      final String matterTypeDescription = "error_description";
+      final Boolean copyCostLimit = false;
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(CategoryOfLawLookupDetail.class)).thenReturn(
+          Mono.error(new RuntimeException("Error")));
+
+      final Mono<CategoryOfLawLookupDetail> result = ebsApiClient.getCategoriesOfLaw(code,
+          matterTypeDescription, copyCostLimit);
+
+      StepVerifier.create(result)
+          .expectError(RuntimeException.class)
+          .verify();
+
+      verify(responseMock).bodyToMono(CategoryOfLawLookupDetail.class);
+    }
+
+  }
+
+  @Nested
+  @DisplayName("getPersonToCaseRelationshipsTests() Tests")
+  class GetPersonToCaseRelationshipsTests {
+
+    @Test
+    @DisplayName("Should return success")
+    void getPersonToCaseRelationships_success() {
+      final String code = "rel_code";
+      final String description = "rel_description";
+      final RelationshipToCaseLookupDetail lookupDetail = new RelationshipToCaseLookupDetail(); //
+      // Populate this as needed
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(RelationshipToCaseLookupDetail.class)).thenReturn(
+          Mono.just(lookupDetail));
+
+      final Mono<RelationshipToCaseLookupDetail> result = ebsApiClient.getPersonToCaseRelationships(
+          code, description);
+
+      StepVerifier.create(result)
+          .expectNext(lookupDetail)
+          .verifyComplete();
+
+      verify(responseMock).bodyToMono(RelationshipToCaseLookupDetail.class);
+    }
+
+    @Test
+    @DisplayName("Should handle error")
+    void getPersonToCaseRelationships_errorHandling() {
+      final String code = "error_rel_code";
+      final String description = "error_rel_description";
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(RelationshipToCaseLookupDetail.class)).thenReturn(
+          Mono.error(new RuntimeException("Error")));
+
+      final Mono<RelationshipToCaseLookupDetail> result = ebsApiClient.getPersonToCaseRelationships(
+          code, description);
+
+      StepVerifier.create(result)
+          .expectError(RuntimeException.class)
+          .verify();
+
+      verify(responseMock).bodyToMono(RelationshipToCaseLookupDetail.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("getProceedings() Tests")
+  class GetProceedingsTests {
+
+    @Test
+    @DisplayName("Should return success")
+    void getProceedings_success() {
+      final ProceedingDetail searchCriteria = new ProceedingDetail();
+      searchCriteria.setCategoryOfLawCode("FAM");
+      searchCriteria.setMatterType("DOM");
+      searchCriteria.setAmendmentOnly(true);
+      final Boolean larScopeFlag = true;
+      final String applicationType = "NEW";
+      final Boolean isLead = true;
+
+      final ProceedingDetails mockDetails = new ProceedingDetails();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(ProceedingDetails.class)).thenReturn(Mono.just(mockDetails));
+
+      final Mono<ProceedingDetails> result = ebsApiClient.getProceedings(searchCriteria,
+          larScopeFlag,
+          applicationType, isLead);
+
+      StepVerifier.create(result)
+          .expectNextMatches(details -> details.equals(mockDetails))
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return error")
+    void getProceedings_error() {
+      final ProceedingDetail searchCriteria = new ProceedingDetail();
+      final Boolean larScopeFlag = false;
+      final String applicationType = "MOD";
+      final Boolean isLead = false;
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(ProceedingDetails.class))
+          .thenReturn(Mono.error(new RuntimeException("Unexpected error")));
+
+      final Mono<ProceedingDetails> result = ebsApiClient.getProceedings(searchCriteria,
+          larScopeFlag,
+          applicationType, isLead);
+
+      StepVerifier.create(result)
+          .expectError(RuntimeException.class)
+          .verify();
+    }
+  }
+
+  @Nested
+  @DisplayName("getClientInvolvementTypes() Tests")
+  class GetClientInvolvementTypesTests {
+
+    @Test
+    @DisplayName("Should return success")
+    void getClientInvolvementTypes_success() {
+      final String proceedingCode = "PROC123";
+      final ClientInvolvementTypeLookupDetail mockDetail =
+          new ClientInvolvementTypeLookupDetail(); // Assume this is populated
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(ClientInvolvementTypeLookupDetail.class)).thenReturn(
+          Mono.just(mockDetail));
+
+      final Mono<ClientInvolvementTypeLookupDetail> result = ebsApiClient.getClientInvolvementTypes(
+          proceedingCode);
+
+      StepVerifier.create(result)
+          .expectNextMatches(detail -> detail.equals(mockDetail))
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return error")
+    void getClientInvolvementTypes_error() {
+      final String proceedingCode = "PROC123";
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(ClientInvolvementTypeLookupDetail.class))
+          .thenReturn(Mono.error(new RuntimeException("Unexpected error")));
+
+      final Mono<ClientInvolvementTypeLookupDetail> result = ebsApiClient.getClientInvolvementTypes(
+          proceedingCode);
+
+      StepVerifier.create(result)
+          .expectError(RuntimeException.class)
+          .verify();
+    }
+  }
+
+  @Nested
+  @DisplayName("getLevelOfServiceTypes() Tests")
+  class GetLevelOfServiceTypesTests {
+
+    @Test
+    @DisplayName("Should return success")
+    void getLevelOfServiceTypes_success() {
+      final String proceedingCode = "PROC123";
+      final String categoryOfLaw = "FAM";
+      final String matterType = "DOM";
+      final LevelOfServiceLookupDetail mockDetail = new LevelOfServiceLookupDetail(); // Assume
+      // this is populated
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(LevelOfServiceLookupDetail.class)).thenReturn(
+          Mono.just(mockDetail));
+
+      final Mono<LevelOfServiceLookupDetail> result = ebsApiClient.getLevelOfServiceTypes(
+          proceedingCode, categoryOfLaw, matterType);
+
+      StepVerifier.create(result)
+          .expectNextMatches(detail -> detail.equals(mockDetail))
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return error")
+    void getLevelOfServiceTypes_error() {
+      final String proceedingCode = "PROC404";
+      final String categoryOfLaw = "UNK";
+      final String matterType = "UNKNOWN";
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(LevelOfServiceLookupDetail.class))
+          .thenReturn(Mono.error(new RuntimeException("Unexpected error")));
+
+      final Mono<LevelOfServiceLookupDetail> result = ebsApiClient.getLevelOfServiceTypes(
+          proceedingCode, categoryOfLaw, matterType);
+
+      StepVerifier.create(result)
+          .expectError(RuntimeException.class)
+          .verify();
+    }
+  }
+
+  @Nested
+  @DisplayName("getEvidenceDocumentTypes() Tests")
+  class GetEvidenceDocumentTypesTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getEvidenceDocumentTypes_returnsData() {
+      final String type = "type1";
+      final String code = "code1";
+      final EvidenceDocumentTypeLookupDetail mockDetail = new EvidenceDocumentTypeLookupDetail();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(EvidenceDocumentTypeLookupDetail.class)).thenReturn(
+          Mono.just(mockDetail));
+
+      final Mono<EvidenceDocumentTypeLookupDetail> result = ebsApiClient.getEvidenceDocumentTypes(
+          type, code);
+
+      StepVerifier.create(result)
+          .expectNextMatches(detail -> detail.equals(mockDetail))
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      assertEquals("/lookup/evidence-document-types?size=1000&type=type1&code=code1",
+          actualUri.toString());
+    }
+
+    @Test
+    @DisplayName("Should return not found")
+    void getEvidenceDocumentTypes_notFound() {
+      final String type = "type1";
+      final String code = "code1";
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(EvidenceDocumentTypeLookupDetail.class)).thenReturn(Mono.error(
+          new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
+
+      when(apiClientErrorHandler.handleApiRetrieveError(any(), eq("Evidence document types"),
+          any())).thenReturn(Mono.empty());
+
+      final Mono<EvidenceDocumentTypeLookupDetail> result = ebsApiClient.getEvidenceDocumentTypes(
+          type, code);
+
+      StepVerifier.create(result)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      assertEquals("/lookup/evidence-document-types?size=1000&type=type1&code=code1",
+          actualUri.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("getAssessmentSummaryAttributes() Tests")
+  class GetAssessmentSummaryAttributesTests {
+
+    @Test
+    @DisplayName("Should return data")
+    void getAssessmentSummaryAttributes_returnsData() {
+      final String summaryType = "summary1";
+      final AssessmentSummaryEntityLookupDetail mockDetail =
+          new AssessmentSummaryEntityLookupDetail();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(AssessmentSummaryEntityLookupDetail.class)).thenReturn(
+          Mono.just(mockDetail));
+
+      final Mono<AssessmentSummaryEntityLookupDetail> result =
+          ebsApiClient.getAssessmentSummaryAttributes(
+              summaryType);
+
+      StepVerifier.create(result)
+          .expectNextMatches(detail -> detail.equals(mockDetail))
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      assertEquals("/lookup/assessment-summary-attributes?size=1000&summary-type=summary1",
+          actualUri.toString());
+    }
+
+    @Test
+    @DisplayName("Should return not found")
+    void getAssessmentSummaryAttributes_notFound() {
+      final String summaryType = "summary1";
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(uriCaptor.capture())).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(AssessmentSummaryEntityLookupDetail.class)).thenReturn(
+          Mono.error(
+              new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
+
+      when(apiClientErrorHandler.handleApiRetrieveError(any(), eq("Assessment summary attributes"),
+          any())).thenReturn(Mono.empty());
+
+      final Mono<AssessmentSummaryEntityLookupDetail> result =
+          ebsApiClient.getAssessmentSummaryAttributes(
+              summaryType);
+
+      StepVerifier.create(result)
+          .verifyComplete();
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      assertEquals("/lookup/assessment-summary-attributes?size=1000&summary-type=summary1",
+          actualUri.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("getMatterTypes(categoryOfLaw) Tests")
+  class GetMatterTypesTests {
+
+    @Test
+    @DisplayName("Should handle success")
+    void getMatterTypes_withCategoryOfLaw_success() {
+      final String categoryOfLaw = "LAW1";
+      final MatterTypeLookupDetail mockDetail = new MatterTypeLookupDetail(); // Assume this is
+      // populated
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(MatterTypeLookupDetail.class)).thenReturn(Mono.just(mockDetail));
+
+      final Mono<MatterTypeLookupDetail> result = ebsApiClient.getMatterTypes(categoryOfLaw);
+
+      StepVerifier.create(result)
+          .expectNext(mockDetail)
+          .verifyComplete();
+
+      verify(responseMock).bodyToMono(MatterTypeLookupDetail.class);
+    }
+
+    @Test
+    @DisplayName("Should handle error")
+    void getMatterTypes_withCategoryOfLaw_errorHandling() {
+      final String categoryOfLaw = "LAW1";
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(MatterTypeLookupDetail.class)).thenReturn(
+          Mono.error(new RuntimeException("Error")));
+
+      final Mono<MatterTypeLookupDetail> result = ebsApiClient.getMatterTypes(categoryOfLaw);
+
+      StepVerifier.create(result)
+          .expectError(RuntimeException.class)
+          .verify();
+
+      verify(responseMock).bodyToMono(MatterTypeLookupDetail.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("getDeclarations() Tests")
+  class GetDeclarationsTests {
+
+    @ParameterizedTest
+    @CsvSource({
+        "DECLARATION_TYPE, BILL_TYPE, /lookup/declarations?size=1000&type=DECLARATION_TYPE&billType"
+            + "=BILL_TYPE",
+        "DECLARATION_TYPE, , /lookup/declarations?size=1000&type=DECLARATION_TYPE",
+        ", BILL_TYPE, /lookup/declarations?size=1000&billType=BILL_TYPE",
+        ", , /lookup/declarations?size=1000"
+    })
+    @DisplayName("getDeclarations parameterized test")
+    void testGetDeclarations(final String type, final String billType, final String expectedUri) {
+      final DeclarationLookupDetail mockDeclarationDetail = new DeclarationLookupDetail();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(DeclarationLookupDetail.class)).thenReturn(
+          Mono.just(mockDeclarationDetail));
+
+      final Mono<DeclarationLookupDetail> result = ebsApiClient.getDeclarations(type, billType);
+
+      StepVerifier.create(result)
+          .expectNext(mockDeclarationDetail)
+          .verifyComplete();
+
+      final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(
+          Function.class);
+      verify(requestHeadersUriMock).uri(uriCaptor.capture());
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      assertEquals(expectedUri, actualUri.toString());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "DECLARATION_TYPE, BILL_TYPE, /lookup/declarations?size=1000&type=DECLARATION_TYPE&billType"
+            + "=BILL_TYPE",
+        "DECLARATION_TYPE, , /lookup/declarations?size=1000&type=DECLARATION_TYPE"
+    })
+    @DisplayName("getDeclarations handles errors in a parameterized test")
+    void testGetDeclarations_handlesError(final String type, final String billType,
+        final String expectedUri) {
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(DeclarationLookupDetail.class)).thenReturn(
+          Mono.error(new RuntimeException("Error")));
+
+      when(apiClientErrorHandler.handleApiRetrieveError(any(), eq("Declarations"),
+          any())).thenReturn(
+          Mono.empty());
+
+      final Mono<DeclarationLookupDetail> result = ebsApiClient.getDeclarations(type, billType);
+
+      StepVerifier.create(result)
+          .verifyComplete();
+
+      final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(
+          Function.class);
+      verify(requestHeadersUriMock).uri(uriCaptor.capture());
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      assertEquals(expectedUri, actualUri.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("getProviderRequestTypes() Tests")
+  class GetProviderRequestTypesTests {
+
+    @ParameterizedTest
+    @CsvSource({
+        "true, type1, /lookup/provider-request-types?size=1000&is-case-related=true&type=type1",
+        "true, , /lookup/provider-request-types?size=1000&is-case-related=true",
+        ", type1, /lookup/provider-request-types?size=1000&type=type1",
+        ", , /lookup/provider-request-types?size=1000"
+    })
+    @DisplayName("Should match URI")
+    void testGetProviderRequestTypes(final Boolean isCaseRelated, final String type,
+        final String expectedUri) {
+      final ProviderRequestTypeLookupDetail mockDetail = new ProviderRequestTypeLookupDetail();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(ProviderRequestTypeLookupDetail.class)).thenReturn(
+          Mono.just(mockDetail));
+
+      final Mono<ProviderRequestTypeLookupDetail> result = ebsApiClient.getProviderRequestTypes(
+          isCaseRelated, type);
+
+      StepVerifier.create(result)
+          .expectNext(mockDetail)
+          .verifyComplete();
+
+      final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(
+          Function.class);
+      verify(requestHeadersUriMock).uri(uriCaptor.capture());
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      assertEquals(expectedUri, actualUri.toString());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "true, type1, /lookup/provider-request-types?size=1000&is-case-related=true&type=type1",
+        "true, , /lookup/provider-request-types?size=1000&is-case-related=true"
+    })
+    @DisplayName("Should handle error")
+    void testGetProviderRequestTypes_handlesError(final Boolean isCaseRelated, final String type,
+        final String expectedUri) {
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(any(Function.class))).thenReturn(requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(ProviderRequestTypeLookupDetail.class)).thenReturn(
+          Mono.error(new RuntimeException("Error")));
+
+      when(apiClientErrorHandler.handleApiRetrieveError(any(), eq("Provider request types"),
+          any())).thenReturn(Mono.empty());
+
+      final Mono<ProviderRequestTypeLookupDetail> result = ebsApiClient.getProviderRequestTypes(
+          isCaseRelated, type);
+
+      StepVerifier.create(result)
+          .verifyComplete();
+
+      final ArgumentCaptor<Function<UriBuilder, URI>> uriCaptor = ArgumentCaptor.forClass(
+          Function.class);
+      verify(requestHeadersUriMock).uri(uriCaptor.capture());
+
+      final Function<UriBuilder, URI> uriFunction = uriCaptor.getValue();
+      final URI actualUri = uriFunction.apply(UriComponentsBuilder.newInstance());
+
+      assertEquals(expectedUri, actualUri.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("postAllocateNextCaseReference() Tests")
+  class PostAllocateNextCaseReferenceTests {
+
+    @Test
+    @DisplayName("Should create case reference")
+    void testPostAllocateNextCaseReference_createsCaseReference() {
+      when(webClientMock.post()).thenReturn(requestBodyUriMock);
+      when(requestBodyUriMock.uri("/case-reference")).thenReturn(requestBodySpec);
+      when(requestBodySpec.retrieve()).thenReturn(responseMock);
+      CaseReferenceSummary caseReferenceSummary = new CaseReferenceSummary().caseReferenceNumber(
+          "123");
+      when(responseMock.bodyToMono(CaseReferenceSummary.class)).thenReturn(
+          Mono.just(caseReferenceSummary));
+
+      final Mono<CaseReferenceSummary> result = ebsApiClient.postAllocateNextCaseReference();
+
+      StepVerifier.create(result)
+          .expectNext(caseReferenceSummary)
+          .verifyComplete();
+
+      verify(responseMock).bodyToMono(CaseReferenceSummary.class);
+    }
+
+    @Test
+    @DisplayName("Should handle errors")
+    void testPostAllocateNextCaseReference_handlesError() {
+      when(webClientMock.post()).thenReturn(requestBodyUriMock);
+      when(requestBodyUriMock.uri("/case-reference")).thenReturn(requestBodySpec);
+      when(requestBodySpec.retrieve()).thenReturn(responseMock);
+      CaseReferenceSummary caseReferenceSummary = new CaseReferenceSummary().caseReferenceNumber(
+          "123");
+      when(responseMock.bodyToMono(CaseReferenceSummary.class))
+          .thenReturn(Mono.error(
+              new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
+
+      when(apiClientErrorHandler.handleApiRetrieveError(any(), eq("case reference"),
+          any())).thenReturn(Mono.empty());
+
+      final Mono<CaseReferenceSummary> result = ebsApiClient.postAllocateNextCaseReference();
+
+      StepVerifier.create(result)
+          .verifyComplete();
+
+      verify(responseMock).bodyToMono(CaseReferenceSummary.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("getClientStatus() Tests")
+  class GetClientStatusTests {
+
+    @Test
+    @DisplayName("Should return successfully")
+    void getClientStatus_Successful() {
+      String transactionId = "123";
+      String loginId = "user1";
+      String userType = "userType";
+      String expectedUri = "/clients/status/{transactionId}";
+
+      TransactionStatus mockTransactionStatus = new TransactionStatus();
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(expectedUri, transactionId)).thenReturn(
+          requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(TransactionStatus.class)).thenReturn(
+          Mono.just(mockTransactionStatus));
+
+      Mono<TransactionStatus> transactionStatusMono = ebsApiClient.getClientStatus(transactionId);
+
+      StepVerifier.create(transactionStatusMono)
+          .expectNextMatches(transactionStatus -> transactionStatus == mockTransactionStatus)
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should handle error")
+    void getClientStatus_Error() {
+      String transactionId = "123";
+      String loginId = "user1";
+      String userType = "userType";
+      String expectedUri = "/clients/status/{transactionId}";
+
+      when(webClientMock.get()).thenReturn(requestHeadersUriMock);
+      when(requestHeadersUriMock.uri(expectedUri, transactionId)).thenReturn(
+          requestHeadersMock);
+      when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.bodyToMono(TransactionStatus.class)).thenReturn(Mono.error(
+          new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
+
+      when(apiClientErrorHandler.handleApiRetrieveError(
+          any(), eq("client transaction status"), eq("transaction id"), eq(transactionId)))
+          .thenReturn(Mono.empty());
+
+      Mono<TransactionStatus> transactionStatusMono = ebsApiClient.getClientStatus(transactionId);
+
+      StepVerifier.create(transactionStatusMono)
+          .verifyComplete();
+    }
+  }
 }

--- a/src/test/java/uk/gov/laa/ccms/caab/client/EbsApiClientTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/client/EbsApiClientTest.java
@@ -51,9 +51,9 @@ import uk.gov.laa.ccms.data.model.ProviderRequestTypeLookupDetail;
 import uk.gov.laa.ccms.data.model.RelationshipToCaseLookupDetail;
 import uk.gov.laa.ccms.data.model.ScopeLimitationDetails;
 import uk.gov.laa.ccms.data.model.StageEndLookupDetail;
+import uk.gov.laa.ccms.data.model.TransactionStatus;
 import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.data.model.UserDetails;
-import uk.gov.laa.ccms.soa.gateway.model.TransactionStatus;
 
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/laa/ccms/caab/client/SoaApiClientTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/client/SoaApiClientTest.java
@@ -35,7 +35,6 @@ import uk.gov.laa.ccms.soa.gateway.model.Document;
 import uk.gov.laa.ccms.soa.gateway.model.NameDetail;
 import uk.gov.laa.ccms.soa.gateway.model.OrganisationDetail;
 import uk.gov.laa.ccms.soa.gateway.model.OrganisationDetails;
-import uk.gov.laa.ccms.soa.gateway.model.TransactionStatus;
 import uk.gov.laa.ccms.soa.gateway.model.UserOptions;
 
 @ExtendWith(MockitoExtension.class)
@@ -275,60 +274,6 @@ class SoaApiClientTest {
         soaApiClient.getClient(clientReferenceNumber, loginId, userType);
 
     StepVerifier.create(clientDetailMono)
-        .verifyComplete();
-  }
-
-  @Test
-  void getClientStatus_Successful() {
-    String transactionId = "123";
-    String loginId = "user1";
-    String userType = "userType";
-    String expectedUri = "/clients/status/{transactionId}";
-
-    TransactionStatus mockTransactionStatus = new TransactionStatus();
-
-    when(soaApiWebClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(expectedUri, transactionId)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.header("SoaGateway-User-Login-Id", loginId)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.header("SoaGateway-User-Role", userType)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(TransactionStatus.class)).thenReturn(Mono.just(mockTransactionStatus));
-
-    Mono<TransactionStatus> transactionStatusMono = soaApiClient.getClientStatus(transactionId, loginId, userType);
-
-    StepVerifier.create(transactionStatusMono)
-        .expectNextMatches(transactionStatus -> transactionStatus == mockTransactionStatus)
-        .verifyComplete();
-  }
-
-  @Test
-  void getClientStatus_Error() {
-    String transactionId = "123";
-    String loginId = "user1";
-    String userType = "userType";
-    String expectedUri = "/clients/status/{transactionId}";
-
-    when(soaApiWebClientMock.get()).thenReturn(requestHeadersUriMock);
-    when(requestHeadersUriMock.uri(expectedUri, transactionId)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.header("SoaGateway-User-Login-Id", loginId)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.header("SoaGateway-User-Role", userType)).thenReturn(
-        requestHeadersMock);
-    when(requestHeadersMock.retrieve()).thenReturn(responseMock);
-    when(responseMock.bodyToMono(TransactionStatus.class)).thenReturn(Mono.error(
-        new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
-
-    when(apiClientErrorHandler.handleApiRetrieveError(
-        any(), eq("client transaction status"), eq("transaction id"), eq(transactionId)))
-        .thenReturn(Mono.empty());
-
-    Mono<TransactionStatus> transactionStatusMono = soaApiClient.getClientStatus(transactionId, loginId, userType);
-
-    StepVerifier.create(transactionStatusMono)
         .verifyComplete();
   }
 

--- a/src/test/java/uk/gov/laa/ccms/caab/controller/submission/ClientSubmissionsInProgressControllerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/controller/submission/ClientSubmissionsInProgressControllerTest.java
@@ -25,8 +25,8 @@ import reactor.core.publisher.Mono;
 import uk.gov.laa.ccms.caab.constants.SubmissionConstants;
 import uk.gov.laa.ccms.caab.model.BaseClientDetail;
 import uk.gov.laa.ccms.caab.service.ClientService;
+import uk.gov.laa.ccms.data.model.TransactionStatus;
 import uk.gov.laa.ccms.data.model.UserDetail;
-import uk.gov.laa.ccms.soa.gateway.model.TransactionStatus;
 
 @ExtendWith(MockitoExtension.class)
 public class ClientSubmissionsInProgressControllerTest {

--- a/src/test/java/uk/gov/laa/ccms/caab/controller/submission/ClientSubmissionsInProgressControllerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/controller/submission/ClientSubmissionsInProgressControllerTest.java
@@ -59,7 +59,7 @@ public class ClientSubmissionsInProgressControllerTest {
     TransactionStatus clientStatus = new TransactionStatus();
     clientStatus.setReferenceNumber("123456");
 
-    when(clientService.getClientStatus(anyString(), anyString(), anyString())).thenReturn(Mono.just(clientStatus));
+    when(clientService.getClientStatus(anyString())).thenReturn(Mono.just(clientStatus));
 
     mockMvc.perform(
             get("/submissions/client-create")
@@ -77,7 +77,7 @@ public class ClientSubmissionsInProgressControllerTest {
 
     TransactionStatus clientStatus = new TransactionStatus();
 
-    when(clientService.getClientStatus(anyString(), anyString(), anyString())).thenReturn(Mono.just(clientStatus));
+    when(clientService.getClientStatus(anyString())).thenReturn(Mono.just(clientStatus));
 
     mockMvc.perform(
             get("/submissions/client-create")
@@ -95,7 +95,7 @@ public class ClientSubmissionsInProgressControllerTest {
 
     final TransactionStatus clientStatus = new TransactionStatus();
 
-    when(clientService.getClientStatus(anyString(), anyString(), anyString())).thenReturn(Mono.just(clientStatus));
+    when(clientService.getClientStatus(anyString())).thenReturn(Mono.just(clientStatus));
 
     when(submissionConstants.getMaxPollCount()).thenReturn(6);
 
@@ -118,7 +118,7 @@ public class ClientSubmissionsInProgressControllerTest {
 
     TransactionStatus clientStatus = new TransactionStatus();
 
-    when(clientService.getClientStatus(anyString(), anyString(), anyString())).thenReturn(Mono.just(clientStatus));
+    when(clientService.getClientStatus(anyString())).thenReturn(Mono.just(clientStatus));
 
     // Set the submission poll count at the threshold (6 in your current logic)
     int submissionPollCount = 6;
@@ -143,7 +143,7 @@ public class ClientSubmissionsInProgressControllerTest {
     final TransactionStatus clientStatus = new TransactionStatus();
     clientStatus.setReferenceNumber("123456");
 
-    when(clientService.getClientStatus(anyString(), anyString(), anyString())).thenReturn(Mono.just(clientStatus));
+    when(clientService.getClientStatus(anyString())).thenReturn(Mono.just(clientStatus));
     when(clientService.updateClientNames(anyString(), any(), any())).thenReturn(Mono.empty());
 
     mockMvc.perform(
@@ -165,7 +165,7 @@ public class ClientSubmissionsInProgressControllerTest {
 
     final TransactionStatus clientStatus = new TransactionStatus();
 
-    when(clientService.getClientStatus(anyString(), anyString(), anyString())).thenReturn(Mono.just(clientStatus));
+    when(clientService.getClientStatus(anyString())).thenReturn(Mono.just(clientStatus));
 
     mockMvc.perform(
             get("/submissions/client-update")

--- a/src/test/java/uk/gov/laa/ccms/caab/service/ClientServiceTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/service/ClientServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.laa.ccms.caab.bean.ClientFormDataBasicDetails;
 import uk.gov.laa.ccms.caab.bean.ClientFormDataContactDetails;
 import uk.gov.laa.ccms.caab.bean.ClientFormDataMonitoringDetails;
 import uk.gov.laa.ccms.caab.bean.ClientSearchCriteria;
+import uk.gov.laa.ccms.caab.client.EbsApiClient;
 import uk.gov.laa.ccms.caab.client.SoaApiClient;
 import uk.gov.laa.ccms.caab.mapper.ClientDetailMapper;
 import uk.gov.laa.ccms.data.model.UserDetail;
@@ -30,6 +31,8 @@ import uk.gov.laa.ccms.soa.gateway.model.TransactionStatus;
 public class ClientServiceTest {
   @Mock
   private SoaApiClient soaApiClient;
+  @Mock
+  private EbsApiClient ebsApiClient;
 
   @Mock
   private ClientDetailMapper clientDetailMapper;
@@ -86,12 +89,10 @@ public class ClientServiceTest {
   @Test
   void getClientStatus_ReturnsClientStatus_Successful() {
     String transactionId = "TRANS123";
-    String loginId = "user1";
-    String userType = "userType";
 
     TransactionStatus mockClientStatus = new TransactionStatus();
 
-    when(soaApiClient.getClientStatus(transactionId, loginId, userType))
+    when(ebsApiClient.getClientStatus(transactionId))
         .thenReturn(Mono.just(mockClientStatus));
 
     Mono<TransactionStatus> clientStatusMono =

--- a/src/test/java/uk/gov/laa/ccms/caab/service/ClientServiceTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/service/ClientServiceTest.java
@@ -20,12 +20,12 @@ import uk.gov.laa.ccms.caab.bean.ClientSearchCriteria;
 import uk.gov.laa.ccms.caab.client.EbsApiClient;
 import uk.gov.laa.ccms.caab.client.SoaApiClient;
 import uk.gov.laa.ccms.caab.mapper.ClientDetailMapper;
+import uk.gov.laa.ccms.data.model.TransactionStatus;
 import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetail;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetailDetails;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetails;
 import uk.gov.laa.ccms.soa.gateway.model.ClientTransactionResponse;
-import uk.gov.laa.ccms.soa.gateway.model.TransactionStatus;
 
 @ExtendWith(MockitoExtension.class)
 public class ClientServiceTest {

--- a/src/test/java/uk/gov/laa/ccms/caab/service/ClientServiceTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/service/ClientServiceTest.java
@@ -23,8 +23,8 @@ import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetail;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetailDetails;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetails;
-import uk.gov.laa.ccms.soa.gateway.model.TransactionStatus;
 import uk.gov.laa.ccms.soa.gateway.model.ClientTransactionResponse;
+import uk.gov.laa.ccms.soa.gateway.model.TransactionStatus;
 
 @ExtendWith(MockitoExtension.class)
 public class ClientServiceTest {
@@ -95,7 +95,7 @@ public class ClientServiceTest {
         .thenReturn(Mono.just(mockClientStatus));
 
     Mono<TransactionStatus> clientStatusMono =
-        clientService.getClientStatus(transactionId, loginId, userType);
+        clientService.getClientStatus(transactionId);
 
     StepVerifier.create(clientStatusMono)
         .expectNextMatches(clientStatus -> clientStatus == mockClientStatus)


### PR DESCRIPTION
Due to the new client transaction status endpoint being created in the EBS API (CCMSPUI-381), the PUI UI needs updating to reflect this as it's currently pointed to SOA API which will be deprecated (CCMSPUI-461).