### PR TITLE
Refactor of S3ClientIntegrationTest to use its own LocalStack instance

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -63,15 +63,6 @@ jobs:
         with:
           arguments: jacocoTestCoverageVerification
 
-      - name: Integration Test Setup - Start LocalStack
-        uses: LocalStack/setup-localstack@v0.2.2
-        with:
-          image-tag: 'latest'
-          install-awslocal: 'true'
-
-      - name: Integration Test Setup - Create S3 Bucket
-        run: ./localstack/init-s3.sh
-
       - name: Integration Test
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
         with:

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -40,15 +40,6 @@ jobs:
         with:
           arguments: jacocoTestCoverageVerification
 
-      - name: Integration Test Setup - Start LocalStack
-        uses: LocalStack/setup-localstack@v0.2.2
-        with:
-          image-tag: 'latest'
-          install-awslocal: 'true'
-
-      - name: Integration Test Setup - Create S3 Bucket
-        run: ./localstack/init-s3.sh
-
       - name: Integration Test
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,6 @@ dependencies {
 	// https://mvnrepository.com/artifact/org.webjars.npm/govuk-frontend
 	implementation 'org.webjars.npm:govuk-frontend:5.7.1'
 	implementation 'org.webjars.npm:ministryofjustice__frontend:3.3.0'
-	//implementation 'org.webjars.npm:@ministryofjustice/frontend:3.0.3'
 
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -95,6 +94,11 @@ dependencies {
 	testImplementation 'io.projectreactor:reactor-test:3.6.1'
 
 	integrationTestImplementation 'org.wiremock:wiremock-standalone:3.3.1'
+
+	implementation platform('org.testcontainers:testcontainers-bom:1.20.4')
+	testImplementation 'org.testcontainers:testcontainers'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:localstack:1.20.4'
 
 }
 

--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
@@ -56,10 +56,9 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
     ExecResult execResult = localstackContainer.execInContainer("awslocal",
         "--endpoint-url=" + localstackContainer.getEndpointOverride(S3).toString(), "s3", "mb",
         "s3://" + BUCKET_NAME);
-    System.out.println("Output of execResult: " + execResult.getStdout());
-    System.out.println("Error output of execResult: " + execResult.getStderr());
-    LOG.info("Output of execResult: {}", execResult.getStdout());
-    LOG.info("Error output of execResult: {}", execResult.getStderr());
+    if(execResult.getExitCode() != 0){
+      throw new RuntimeException(execResult.getStdout());
+    }
   }
 
   @AfterAll

--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
@@ -18,8 +18,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -36,29 +34,17 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
 
   public static final String BUCKET_NAME = "testbucket";
 
-  private static final Logger LOG = LoggerFactory.getLogger(S3ClientIntegrationTest.class);
-
   @Container
   static LocalStackContainer localstackContainer = new LocalStackContainer(
-      DockerImageName.parse("localstack/localstack:latest")
-  ).withServices(LocalStackContainer.Service.S3);
+      DockerImageName.parse("localstack/localstack:s3-latest")
+  )
+      .withServices(LocalStackContainer.Service.S3);
 
   @Autowired
   private S3ApiClient s3ApiClient;
 
   @Autowired
   private S3Template s3Template;
-
-  /*@BeforeAll
-  static void beforeAll() throws IOException, InterruptedException {
-    // Creates bucket
-    ExecResult execResult = localstackContainer.execInContainer("awslocal",
-        "--endpoint-url=" + localstackContainer.getEndpointOverride(S3).toString(), "s3", "mb",
-        "s3://" + BUCKET_NAME);
-    if (execResult.getExitCode() != 0) {
-      throw new RuntimeException(execResult.getStdout());
-    }
-  }*/
 
   @BeforeEach
   void beforeEach(){

--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -41,7 +40,7 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
 
   @Container
   static LocalStackContainer localstackContainer = new LocalStackContainer(
-      DockerImageName.parse("localstack/localstack:4.0.3")
+      DockerImageName.parse("localstack/localstack:latest")
   ).withServices(LocalStackContainer.Service.S3);
 
   @Autowired
@@ -50,14 +49,22 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
   @Autowired
   private S3Template s3Template;
 
-  @BeforeAll
-  static void beforeEach() throws IOException, InterruptedException {
+  /*@BeforeAll
+  static void beforeAll() throws IOException, InterruptedException {
     // Creates bucket
     ExecResult execResult = localstackContainer.execInContainer("awslocal",
         "--endpoint-url=" + localstackContainer.getEndpointOverride(S3).toString(), "s3", "mb",
         "s3://" + BUCKET_NAME);
     if (execResult.getExitCode() != 0) {
       throw new RuntimeException(execResult.getStdout());
+    }
+  }*/
+
+  @BeforeEach
+  void beforeEach(){
+    // Check if bucket exists, if not then create the bucket
+    if(!s3Template.bucketExists(BUCKET_NAME)){
+      s3Template.createBucket(BUCKET_NAME);
     }
   }
 

--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
@@ -56,6 +56,8 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
     ExecResult execResult = localstackContainer.execInContainer("awslocal",
         "--endpoint-url=" + localstackContainer.getEndpointOverride(S3).toString(), "s3", "mb",
         "s3://" + BUCKET_NAME);
+    System.out.println("Output of execResult: " + execResult.getStdout());
+    System.out.println("Error output of execResult: " + execResult.getStderr());
     LOG.info("Output of execResult: {}", execResult.getStdout());
     LOG.info("Error output of execResult: {}", execResult.getStderr());
   }

--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -49,7 +48,7 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
   @BeforeAll
   static void beforeEach() throws IOException, InterruptedException {
     // Creates bucket
-    ExecResult execResult = localstackContainer.execInContainer("awslocal",
+    localstackContainer.execInContainer("awslocal",
         "--endpoint-url=" + localstackContainer.getEndpointOverride(S3).toString(), "s3", "mb",
         "s3://" + BUCKET_NAME);
   }

--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
@@ -41,7 +41,7 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
 
   @Container
   static LocalStackContainer localstackContainer = new LocalStackContainer(
-      DockerImageName.parse("localstack/localstack:4.0.5")
+      DockerImageName.parse("localstack/localstack:4.0.3")
   ).withServices(LocalStackContainer.Service.S3);
 
   @Autowired
@@ -56,7 +56,7 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
     ExecResult execResult = localstackContainer.execInContainer("awslocal",
         "--endpoint-url=" + localstackContainer.getEndpointOverride(S3).toString(), "s3", "mb",
         "s3://" + BUCKET_NAME);
-    if(execResult.getExitCode() != 0){
+    if (execResult.getExitCode() != 0) {
       throw new RuntimeException(execResult.getStdout());
     }
   }

--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
@@ -37,7 +37,7 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
 
   @Container
   static LocalStackContainer localstackContainer = new LocalStackContainer(
-      DockerImageName.parse("localstack/localstack:4.0.3")
+      DockerImageName.parse("localstack/localstack:latest")
   ).withServices(LocalStackContainer.Service.S3);
 
   @Autowired
@@ -52,7 +52,6 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
     ExecResult execResult = localstackContainer.execInContainer("awslocal",
         "--endpoint-url=" + localstackContainer.getEndpointOverride(S3).toString(), "s3", "mb",
         "s3://" + BUCKET_NAME);
-    System.out.println(execResult.getStdout());
   }
 
   @AfterAll

--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
@@ -18,10 +18,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -33,6 +36,8 @@ import uk.gov.laa.ccms.caab.AbstractIntegrationTest;
 public class S3ClientIntegrationTest extends AbstractIntegrationTest {
 
   public static final String BUCKET_NAME = "testbucket";
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3ClientIntegrationTest.class);
 
   @Container
   static LocalStackContainer localstackContainer = new LocalStackContainer(
@@ -48,9 +53,11 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
   @BeforeAll
   static void beforeEach() throws IOException, InterruptedException {
     // Creates bucket
-    localstackContainer.execInContainer("awslocal",
+    ExecResult execResult = localstackContainer.execInContainer("awslocal",
         "--endpoint-url=" + localstackContainer.getEndpointOverride(S3).toString(), "s3", "mb",
         "s3://" + BUCKET_NAME);
+    LOG.info("Output of execResult: {}", execResult.getStdout());
+    LOG.info("Error output of execResult: {}", execResult.getStderr());
   }
 
   @AfterAll

--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
@@ -3,6 +3,7 @@ package uk.gov.laa.ccms.caab.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
 import io.awspring.cloud.s3.S3Resource;
 import io.awspring.cloud.s3.S3Template;
@@ -13,15 +14,24 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
 import uk.gov.laa.ccms.caab.AbstractIntegrationTest;
 
 @SpringBootTest
 public class S3ClientIntegrationTest extends AbstractIntegrationTest {
+
+  DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:3.5.0");
+
+  @Rule
+  public LocalStackContainer localstack = new LocalStackContainer(localstackImage)
+      .withServices(S3);
 
   @Autowired
   private S3ApiClient s3ApiClient;
@@ -31,7 +41,6 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
 
   @Value("${laa.ccms.s3.buckets.document-bucket.name}")
   private String bucketName;
-
 
   @AfterEach
   void cleanup() {

--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/S3ClientIntegrationTest.java
@@ -41,7 +41,7 @@ public class S3ClientIntegrationTest extends AbstractIntegrationTest {
 
   @Container
   static LocalStackContainer localstackContainer = new LocalStackContainer(
-      DockerImageName.parse("localstack/localstack:latest")
+      DockerImageName.parse("localstack/localstack:4.0.5")
   ).withServices(LocalStackContainer.Service.S3);
 
   @Autowired


### PR DESCRIPTION
The original implementation of `S3ClientIntegrationTest` used whatever localstack instance was currently running in docker. This meant that if you don't have localstack running locally, it would fail. Now that that the test spins it's own version of localstack, you shouldn't need to worry about running localstack yourself. Also ensures that the test runs against the same version of localstack for everyone.