### PR TITLE
Update soa-api version to 0.0.49

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
 	implementation 'uk.gov.laa.ccms.data:data-api:0.0.35'
 
-	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.49-2f86945-SNAPSHOT'
+	implementation 'uk.gov.laa.ccms.soa.gateway:soa-gateway-api:0.0.49'
 
 	implementation 'uk.gov.laa.ccms.caab:caab-api:0.0.40'
 


### PR DESCRIPTION
Automatic PR raised by GitHub Actions to update soa-api version to 0.0.49