### PR TITLE
Case & Client transaction status 404 not found

### DIFF
--- a/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
@@ -2,6 +2,7 @@ package uk.gov.laa.ccms.caab.client;
 
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -842,6 +843,7 @@ public class EbsApiClient extends BaseApiClient {
         .get()
         .uri("/clients/status/{transactionId}", transactionId)
         .retrieve()
+        .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.empty())
         .bodyToMono(TransactionStatus.class)
         .onErrorResume(e -> ebsApiClientErrorHandler.handleApiRetrieveError(
             e, "client transaction status", "transaction id", transactionId));
@@ -859,6 +861,7 @@ public class EbsApiClient extends BaseApiClient {
         .get()
         .uri("/cases/status/{transactionId}", transactionId)
         .retrieve()
+        .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.empty())
         .bodyToMono(TransactionStatus.class)
         .onErrorResume(e -> ebsApiClientErrorHandler.handleApiRetrieveError(
             e, "case transaction status", "transaction id", transactionId));

--- a/src/test/java/uk/gov/laa/ccms/caab/client/EbsApiClientTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/client/EbsApiClientTest.java
@@ -1618,6 +1618,7 @@ public class EbsApiClientTest {
       when(requestHeadersUriMock.uri(expectedUri, transactionId)).thenReturn(
           requestHeadersMock);
       when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.onStatus(any(), any())).thenReturn(responseMock);
       when(responseMock.bodyToMono(TransactionStatus.class)).thenReturn(
           Mono.just(mockTransactionStatus));
 
@@ -1638,6 +1639,7 @@ public class EbsApiClientTest {
       when(requestHeadersUriMock.uri(expectedUri, transactionId)).thenReturn(
           requestHeadersMock);
       when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.onStatus(any(), any())).thenReturn(responseMock);
       when(responseMock.bodyToMono(TransactionStatus.class)).thenReturn(Mono.error(
           new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
 
@@ -1668,6 +1670,7 @@ public class EbsApiClientTest {
       when(requestHeadersUriMock.uri(expectedUri, transactionId)).thenReturn(
           requestHeadersMock);
       when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.onStatus(any(), any())).thenReturn(responseMock);
       when(responseMock.bodyToMono(TransactionStatus.class)).thenReturn(
           Mono.just(mockTransactionStatus));
 
@@ -1688,6 +1691,7 @@ public class EbsApiClientTest {
       when(requestHeadersUriMock.uri(expectedUri, transactionId)).thenReturn(
           requestHeadersMock);
       when(requestHeadersMock.retrieve()).thenReturn(responseMock);
+      when(responseMock.onStatus(any(), any())).thenReturn(responseMock);
       when(responseMock.bodyToMono(TransactionStatus.class)).thenReturn(Mono.error(
           new WebClientResponseException(HttpStatus.NOT_FOUND.value(), "", null, null, null)));
 


### PR DESCRIPTION
Fixed an issue where the application would error due to the case or client transaction status not being ready yet and the EBS API returning a 404 where originally the SOA API used to return a 200 with an empty body.

To embrace the new 404 status on EBS API, now the PUI UI checks that if it's a 4xx error, it returns an empty Mono instead of failing out right to allow the client/case creation check to be presented to the user.