### PR TITLE
Update dependabot, bump versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,8 +38,8 @@ updates:
       interval: "weekly"
     groups:
       gradle-updates:
-        patterns:
-          - "!uk.gov.laa.ccms.*" # All external Gradle dependencies
+        exclude-patterns:
+          - "uk.gov.laa.ccms.*"
       internal-packages:
         patterns:
           - "uk.gov.laa.ccms.*" # All internal Gradle dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,3 +51,11 @@ updates:
       npm-updates:
         patterns:
           - "**" # Matches all NPM packages
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "**"

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -49,9 +49,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build & test
-        run: ./gradlew build jacocoTestCoverageVerification
+        run: ./gradlew build
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration test
         run: ./gradlew integrationTest
@@ -63,6 +66,30 @@ jobs:
         with:
           name: caab-jar
           path: build/libs/laa-ccms-caab-0.0.1-SNAPSHOT.jar
+
+      - name: Upload checkstyle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: build/reports/checkstyle
+          retention-days: 14
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests
+          retention-days: 14
+
+      - name: Upload jacoco coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-report
+          path: build/reports/jacoco
+          retention-days: 14
 
   vulnerability-report:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -45,30 +45,24 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: build
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build & test
+        run: ./gradlew build jacocoTestCoverageVerification
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+
+      - name: Integration test
+        run: ./gradlew integrationTest
+        env:
+          AWS_REGION: eu-west-2
 
       - name: upload jarfile
         uses: actions/upload-artifact@v4
         with:
           name: caab-jar
           path: build/libs/laa-ccms-caab-0.0.1-SNAPSHOT.jar
-
-      - name: Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: jacocoTestCoverageVerification
-
-      - name: Integration Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: integrationTest
-        env:
-          AWS_REGION: eu-west-2
 
   vulnerability-report:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -81,6 +81,7 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       SNYK_ORG: legal-aid-agency
       SNYK_TEST_EXCLUDE: build
+      SNYK_TARGET_REFERENCE: main
       GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
 
     steps:
@@ -90,12 +91,12 @@ jobs:
         continue-on-error: true
         with:
           command: monitor
-          args: --org=$SNYK_ORG --all-projects --exclude=$SNYK_TEST_EXCLUDE
+          args: --org=$SNYK_ORG --all-projects --exclude=$SNYK_TEST_EXCLUDE --target-reference=$SNYK_TARGET_REFERENCE
       - name: Generate sarif Snyk report
         uses: snyk/actions/gradle@0.4.0
         continue-on-error: true
         with:
-          args: --org=$SNYK_ORG --all-projects --exclude=$SNYK_TEST_EXCLUDE --sarif-file-output=snyk-report.sarif
+          args: --org=$SNYK_ORG --all-projects --exclude=$SNYK_TEST_EXCLUDE --target-reference=$SNYK_TARGET_REFERENCE --sarif-file-output=snyk-report.sarif
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
       - name: Fix undefined values

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -28,22 +28,16 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: build
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build & test
+        run: ./gradlew build jacocoTestCoverageVerification
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
 
-      - name: Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: jacocoTestCoverageVerification
-
-      - name: Integration Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: integrationTest
+      - name: Integration test
+        run: ./gradlew integrationTest
         env:
           AWS_REGION: eu-west-2
 

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -54,6 +54,7 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       SNYK_ORG: legal-aid-agency
       SNYK_TEST_EXCLUDE: build
+      SNYK_TARGET_REFERENCE: main
 
     steps:
       - uses: actions/checkout@v3
@@ -65,7 +66,7 @@ jobs:
           export PATH="$HOME/.local/bin/:$PATH"
           npm install -g snyk-delta
       - name: Identify new vulnerabilities
-        run: ./snyk/snyk_delta_all_projects.sh --org=$SNYK_ORG --exclude=$SNYK_TEST_EXCLUDE
+        run: ./snyk/snyk_delta_all_projects.sh --org=$SNYK_ORG --exclude=$SNYK_TEST_EXCLUDE --target-reference=$SNYK_TARGET_REFERENCE
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
       - name: Run code test

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -32,14 +32,41 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build & test
-        run: ./gradlew build jacocoTestCoverageVerification
+        run: ./gradlew build
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration test
         run: ./gradlew integrationTest
         env:
           AWS_REGION: eu-west-2
+
+      - name: Upload checkstyle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: build/reports/checkstyle
+          retention-days: 14
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests
+          retention-days: 14
+
+      - name: Upload jacoco coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-report
+          path: build/reports/jacoco
+          retention-days: 14
 
   vulnerability-scan:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Please ensure this matches the command used by the [pr-merge](.github/workflows/
 workflow to maintain consistency.
 
 ```shell
-snyk monitor --org=legal-aid-agency --all-projects --exclude=build
+snyk monitor --org=legal-aid-agency --all-projects --exclude=build --target-reference=main
 ```
 
 You should then see the new vulnerability in the LAA Dashboard, otherwise it is a new

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'net.researchgate.release' version '3.0.2'
-	id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.24'
+	id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.25'
 }
 
 subprojects {
@@ -106,6 +106,8 @@ test {
 
 	// Hide warning for dynamic loading of agents https://github.com/mockito/mockito/issues/3037
 	jvmArgs '-XX:+EnableDynamicAgentLoading'
+
+	finalizedBy jacocoTestReport
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ dependencies {
 
 	integrationTestImplementation 'org.wiremock:wiremock-standalone:3.3.1'
 
-	implementation platform('org.testcontainers:testcontainers-bom:1.20.4')
+	testImplementation platform('org.testcontainers:testcontainers-bom:1.20.4')
 	testImplementation 'org.testcontainers:testcontainers'
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:localstack:1.20.4'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'net.researchgate.release' version '3.0.2'
-	id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.20'
+	id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.24'
 }
 
 subprojects {


### PR DESCRIPTION
* Dependabot
  * Scan for github-actions updates
  * Scan for SB common library updates
* Snyk
  * Consolidate reporting - duplicate reports are created when running `monitor` from local cli vs in the pipeline. Adding `--target-reference=main` to all commands should make them point to one report. 
* Bump to latest SB common library version
  * Fixed bug where duplicate unit tests would run twice in pipelines (`build` would run tests, followed by `jacocoTestVerification`)
* Workflows
  * Replace deprecated `gradle-build-action` with `setup-gradle` action
  * Upload checkstyle, test and jacoco coverage artifacts
  * Fixed bug where test coverage verification would run without jacoco report (effectively always passing)