### PR TITLE
Fix: Add user details to error page model

### DIFF
--- a/src/main/java/uk/gov/laa/ccms/caab/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/advice/GlobalExceptionHandler.java
@@ -23,11 +23,13 @@ public class GlobalExceptionHandler {
    * error response.
    *
    * @param e The EbsApiClientException that was thrown.
+   * @param session The HttpSession for the current request.
    * @param model The Model object to which error information will be added.
    * @return The name of the error view to be displayed.
    */
   @ExceptionHandler(value = {EbsApiClientException.class})
-  public String handleDataApiClientException(EbsApiClientException e,  HttpSession session, Model model) {
+  public String handleDataApiClientException(EbsApiClientException e,
+      HttpSession session, Model model) {
     // This exception is thrown when there's a low-level, resource-specific error,
     // such as an I/O error, Log the error details
     return generalErrorView(model, session, e);
@@ -38,11 +40,13 @@ public class GlobalExceptionHandler {
    * appropriate error response.
    *
    * @param e The CaabApplicationException that was thrown.
+   * @param session The HttpSession for the current request.
    * @param model The Model object to which error information will be added.
    * @return The name of the error view to be displayed.
    */
   @ExceptionHandler(value = {CaabApplicationException.class})
-  public String handleCaabApplicationException(CaabApplicationException e,  HttpSession session, Model model) {
+  public String handleCaabApplicationException(CaabApplicationException e,
+      HttpSession session, Model model) {
     return generalErrorView(model, session, e);
   }
 
@@ -51,6 +55,7 @@ public class GlobalExceptionHandler {
    * appropriate error response.
    *
    * @param e The ServletRequestBindingException that was thrown.
+   * @param session The HttpSession for the current request.
    * @param model The Model object to which error information will be added.
    * @return The name of the error view to be displayed.
    */

--- a/src/main/java/uk/gov/laa/ccms/caab/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/advice/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package uk.gov.laa.ccms.caab.advice;
 
+import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import uk.gov.laa.ccms.caab.client.EbsApiClientException;
+import uk.gov.laa.ccms.caab.constants.SessionConstants;
 import uk.gov.laa.ccms.caab.exception.CaabApplicationException;
 
 /**
@@ -25,10 +27,10 @@ public class GlobalExceptionHandler {
    * @return The name of the error view to be displayed.
    */
   @ExceptionHandler(value = {EbsApiClientException.class})
-  public String handleDataApiClientException(EbsApiClientException e, Model model) {
+  public String handleDataApiClientException(EbsApiClientException e,  HttpSession session, Model model) {
     // This exception is thrown when there's a low-level, resource-specific error,
     // such as an I/O error, Log the error details
-    return generalErrorView(model, e);
+    return generalErrorView(model, session, e);
   }
 
   /**
@@ -40,8 +42,8 @@ public class GlobalExceptionHandler {
    * @return The name of the error view to be displayed.
    */
   @ExceptionHandler(value = {CaabApplicationException.class})
-  public String handleCaabApplicationException(CaabApplicationException e, Model model) {
-    return generalErrorView(model, e);
+  public String handleCaabApplicationException(CaabApplicationException e,  HttpSession session, Model model) {
+    return generalErrorView(model, session, e);
   }
 
   /**
@@ -55,12 +57,15 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(value = {ServletRequestBindingException.class})
   public String handleServletRequestBindingException(
       ServletRequestBindingException e,
+      HttpSession session,
       Model model) {
-    return generalErrorView(model, e);
+    return generalErrorView(model, session, e);
   }
 
-  private String generalErrorView(Model model, Exception e) {
+  private String generalErrorView(Model model, HttpSession session, Exception e) {
     log.error("{} caught by GlobalExceptionHandler", e.getClass().getName(), e);
+    model.addAttribute(SessionConstants.USER_DETAILS,
+        session.getAttribute(SessionConstants.USER_DETAILS));
     model.addAttribute("error", e.getLocalizedMessage());
     model.addAttribute("errorTime", System.currentTimeMillis());
     return "error";

--- a/src/test/java/uk/gov/laa/ccms/caab/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/advice/GlobalExceptionHandlerTest.java
@@ -2,6 +2,7 @@ package uk.gov.laa.ccms.caab.advice;
 
 import static org.mockito.Mockito.verify;
 
+import jakarta.servlet.http.HttpSession;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,6 +23,9 @@ public class GlobalExceptionHandlerTest {
   @Mock
   private Model model;
 
+  @Mock
+  private HttpSession session;
+
   @InjectMocks
   private GlobalExceptionHandler globalExceptionHandler;
 
@@ -30,7 +34,7 @@ public class GlobalExceptionHandlerTest {
     final String errorMsg = "Test Exception";
     EbsApiClientException e = new EbsApiClientException(errorMsg);
 
-    globalExceptionHandler.handleDataApiClientException(e, model);
+    globalExceptionHandler.handleDataApiClientException(e, session, model);
 
     verify(model).addAttribute("error", errorMsg);
   }
@@ -40,7 +44,7 @@ public class GlobalExceptionHandlerTest {
     final String errorMsg = "Test Exception";
     CaabApplicationException e = new CaabApplicationException(errorMsg);
 
-    globalExceptionHandler.handleCaabApplicationException(e, model);
+    globalExceptionHandler.handleCaabApplicationException(e, session, model);
 
     verify(model).addAttribute("error", errorMsg);
   }
@@ -50,7 +54,7 @@ public class GlobalExceptionHandlerTest {
     final String errorMsg = "Test Exception";
     ServletRequestBindingException e = new ServletRequestBindingException(errorMsg);
 
-    globalExceptionHandler.handleServletRequestBindingException(e, model);
+    globalExceptionHandler.handleServletRequestBindingException(e, session, model);
 
     verify(model).addAttribute("error", errorMsg);
   }


### PR DESCRIPTION
When the user is directed to the error page after an unexpected error, the page fails to render due to user details not being available to the model to check user actions (required for navigation links). A generic error page is rendered instead and the original error message is lost. This fix adds user details from the session to the model for the error page.

Fixes the following error:

```
org.thymeleaf.exceptions.TemplateInputException: An error happened during template parsing (template: "URL [file:src/main/resources/templates/error.html]")
...
Caused by: org.attoparser.ParseException: Exception evaluating SpringEL expression: "#lists.contains(user?.functions, 'YCA')" (template: "partials/header" - line 42, col 29)
```

See below an example for the current permission issue affecting retrieval of notifications in dev.

Error page without fix:
![Screenshot 2025-02-19 at 15 24 57](https://github.com/user-attachments/assets/9681da54-9344-4b02-9f87-c3f6e8ddd4d4)


Error page with fix:
![Screenshot 2025-02-19 at 15 26 12](https://github.com/user-attachments/assets/a80eeafb-7b5b-421c-a5d6-1dd5cf9482fc)
