### PR TITLE
Fix: Notification response layout

### DIFF
--- a/src/main/resources/templates/notifications/notification.html
+++ b/src/main/resources/templates/notifications/notification.html
@@ -122,23 +122,23 @@
           </table>
         </div>
       </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <div th:if="${#lists.contains(user.functions, 'EVID') and notification.evidenceAllowed == true}">
+            <p class="govuk-body govuk-!-text-align-left">
+            <div
+              th:replace="~{partials/actions :: restrictedActionLink(#{notifications.provideDocumentsOrEvidence}, ${user.functions}, 'EVID', true, 'govuk-button&#45;&#45;secondary', @{/notifications/{notification_id}/provide-documents-or-evidence(notification_id=${notification.getNotificationId})}, false)}">
+            </div>
+            </p>
+          </div>
+        </div>
+      </div>
       <div class="govuk-grid-row" th:if="${notification.notificationOpenIndicator}">
         <div class="govuk-grid-column-full">
           <h2 class="govuk-heading-m" th:text="#{notifications.subHeading.notificationResponse}"/>
           <div th:replace="~{partials/forms :: simpleDropdown('action', #{notifications.response}, ${notification.availableResponses})}"></div>
           <div th:if="${notification.notificationOpenIndicator and notification.notificationType != 'N'}">
             <div th:replace="~{partials/forms :: largeTextInput('message',  #{notifications.messageToLAA}, 2000)}"></div>
-          </div>
-        </div>
-      </div>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <div th:if="${#lists.contains(user.functions, 'EVID') and notification.evidenceAllowed == true}">
-          <p class="govuk-body govuk-!-text-align-left">
-          <div
-            th:replace="~{partials/actions :: restrictedActionLink(#{notifications.provideDocumentsOrEvidence}, ${user.functions}, 'EVID', true, 'govuk-button&#45;&#45;secondary', @{/notifications/{notification_id}/provide-documents-or-evidence(notification_id=${notification.getNotificationId})}, false)}">
-            </div>
-            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Currently:
![Screenshot 2025-03-20 at 13 17 35](https://github.com/user-attachments/assets/11142b68-6791-4a00-a926-b68a606b4877)

but should be:
![Screenshot 2025-03-20 at 13 09 57](https://github.com/user-attachments/assets/72cca7cc-3750-471a-a453-b2f228fafff5)
