### PR TITLE
replacing call to get user using user id, not login id

### DIFF
--- a/src/integrationTest/java/uk/gov/laa/ccms/caab/client/EbsApiClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/laa/ccms/caab/client/EbsApiClientIntegrationTest.java
@@ -72,7 +72,7 @@ public class EbsApiClientIntegrationTest extends AbstractIntegrationTest {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  private static final String USER_ERROR_MESSAGE = "Failed to retrieve User with login id: %s";
+  private static final String USER_ERROR_MESSAGE = "Failed to retrieve User with user id: %s";
   private static final String CASE_REFERENCE_MESSAGE = "Failed to retrieve case reference";
 
   @Test
@@ -81,9 +81,9 @@ public class EbsApiClientIntegrationTest extends AbstractIntegrationTest {
     final String userJson = objectMapper.writeValueAsString(expectedUserDetail);
 
     wiremock.stubFor(
-        get("/users/%s".formatted(expectedUserDetail.getLoginId())).willReturn(okJson(userJson)));
+        get("/users/%s".formatted(expectedUserDetail.getUserId())).willReturn(okJson(userJson)));
 
-    final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(expectedUserDetail.getLoginId());
+    final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(expectedUserDetail.getUserId());
 
     final UserDetail userDetails = userDetailsMono.block();
 
@@ -92,12 +92,12 @@ public class EbsApiClientIntegrationTest extends AbstractIntegrationTest {
 
   @Test
   public void testGetUser_notFound() {
-    final String loginId = "user1";
-    final String expectedMessage = USER_ERROR_MESSAGE.formatted(loginId);
+    final Integer userId = 1;
+    final String expectedMessage = USER_ERROR_MESSAGE.formatted(userId);
 
-    wiremock.stubFor(get("/users/%s".formatted(loginId)).willReturn(notFound()));
+    wiremock.stubFor(get("/users/%s".formatted(userId)).willReturn(notFound()));
 
-    final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(loginId);
+    final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(userId);
 
     StepVerifier.create(userDetailsMono)
         .expectErrorMatches(
@@ -274,16 +274,17 @@ public class EbsApiClientIntegrationTest extends AbstractIntegrationTest {
   @Test
   public void testGetUserNotificationSummary_returnData() throws Exception {
     final String loginId = "user1";
+    final Integer userId = 1;
     final NotificationSummary expectedNotificationsummary = buildUserNotificationSummary();
     final String notificationSummaryJson =
         objectMapper.writeValueAsString(expectedNotificationsummary);
 
     wiremock.stubFor(
-        get("/users/%s/notifications/summary".formatted(loginId))
+        get("/users/%s/notifications/summary".formatted(userId))
             .willReturn(okJson(notificationSummaryJson)));
 
     final Mono<NotificationSummary> userNotificationSummary =
-        ebsApiClient.getUserNotificationSummary(loginId);
+        ebsApiClient.getUserNotificationSummary(userId);
 
     final NotificationSummary userDetails = userNotificationSummary.block();
 
@@ -292,14 +293,15 @@ public class EbsApiClientIntegrationTest extends AbstractIntegrationTest {
 
   @Test
   public void testGetUserNotificationSummary_notFound() {
+    final Integer userId = 1;
     final String loginId = "user1";
-    final String expectedMessage = USER_ERROR_MESSAGE.formatted(loginId);
+    final String expectedMessage = USER_ERROR_MESSAGE.formatted(userId);
 
     wiremock.stubFor(
-        get("/users/%s/notifications/summary".formatted(loginId)).willReturn(notFound()));
+        get("/users/%s/notifications/summary".formatted(userId)).willReturn(notFound()));
 
     final Mono<NotificationSummary> notificationSummary =
-        ebsApiClient.getUserNotificationSummary(loginId);
+        ebsApiClient.getUserNotificationSummary(userId);
 
     StepVerifier.create(notificationSummary)
         .expectErrorMatches(

--- a/src/main/java/uk/gov/laa/ccms/caab/advice/SamlPrincipalControllerAdvice.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/advice/SamlPrincipalControllerAdvice.java
@@ -50,11 +50,11 @@ public class SamlPrincipalControllerAdvice {
         user = (UserDetail) session.getAttribute("user");
 
         if (!user.getLoginId().equals(loginId)) {
-          user = userService.getUser(user.getLoginId()).block();
+          user = userService.getUser(user.getUserId()).block();
         }
 
       } else {
-        user = userService.getUser(user.getLoginId()).block();
+        user = userService.getUser(user.getUserId()).block();
       }
 
       model.addAttribute("user", user);

--- a/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
@@ -95,7 +95,7 @@ public class EbsApiClient extends BaseApiClient {
   public Mono<UserDetail> getUserByLoginId(final String loginId) {
     return webClient
         .get()
-        .uri(uriBuilder -> uriBuilder.path("/user-lookup").queryParam("login-id", loginId).build())
+        .uri(uriBuilder -> uriBuilder.path("/users/lookup").queryParam("login-id", loginId).build())
         .retrieve()
         .bodyToMono(UserDetail.class)
         .onErrorResume(

--- a/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
@@ -87,6 +87,22 @@ public class EbsApiClient extends BaseApiClient {
   }
 
   /**
+   * Retrieves user details based on the login ID.
+   *
+   * @param loginId The login ID of the user.
+   * @return A Mono containing the UserDetail or an error handler if an error occurs.
+   */
+  public Mono<UserDetail> getUserByLoginId(final String loginId) {
+    return webClient
+        .get()
+        .uri(uriBuilder -> uriBuilder.path("/user-lookup").queryParam("login-id", loginId).build())
+        .retrieve()
+        .bodyToMono(UserDetail.class)
+        .onErrorResume(
+            e -> ebsApiClientErrorHandler.handleApiRetrieveError(e, "User", "login id", loginId));
+  }
+
+  /**
    * Retrieves a summary of notification counts for a user based on their login ID.
    *
    * @param userId the userId ID of the user whose notification summary is to be retrieved

--- a/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/client/EbsApiClient.java
@@ -71,33 +71,37 @@ public class EbsApiClient extends BaseApiClient {
   /**
    * Retrieves user details based on the login ID.
    *
-   * @param loginId The login ID of the user.
+   * @param userId The user ID of the user.
    * @return A Mono containing the UserDetail or an error handler if an error occurs.
    */
-  public Mono<UserDetail> getUser(final String loginId) {
+  public Mono<UserDetail> getUser(final Integer userId) {
     return webClient
         .get()
-        .uri("/users/{loginId}", loginId)
+        .uri("/users/{userId}", userId)
         .retrieve()
         .bodyToMono(UserDetail.class)
         .onErrorResume(
-            e -> ebsApiClientErrorHandler.handleApiRetrieveError(e, "User", "login id", loginId));
+            e ->
+                ebsApiClientErrorHandler.handleApiRetrieveError(
+                    e, "User", "user id", userId.toString()));
   }
 
   /**
    * Retrieves a summary of notification counts for a user based on their login ID.
    *
-   * @param loginId the login ID of the user whose notification summary is to be retrieved
+   * @param userId the userId ID of the user whose notification summary is to be retrieved
    * @return a Mono emitting the NotificationSummary for the specified user
    */
-  public Mono<NotificationSummary> getUserNotificationSummary(final String loginId) {
+  public Mono<NotificationSummary> getUserNotificationSummary(final Integer userId) {
     return webClient
         .get()
-        .uri("/users/{loginId}/notifications/summary", loginId)
+        .uri("/users/{userId}/notifications/summary", userId)
         .retrieve()
         .bodyToMono(NotificationSummary.class)
         .onErrorResume(
-            e -> ebsApiClientErrorHandler.handleApiRetrieveError(e, "User", "login id", loginId));
+            e ->
+                ebsApiClientErrorHandler.handleApiRetrieveError(
+                    e, "User", "user id", userId.toString()));
   }
 
   /**

--- a/src/main/java/uk/gov/laa/ccms/caab/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/config/SecurityConfiguration.java
@@ -147,19 +147,21 @@ public class SecurityConfiguration {
       } else {
         authorities.addAll(authentication.getAuthorities());
       }
+
+      // authentication.getPrincipal() is going to be email address here....
       String principal = authentication.getName();
       authorities.addAll(getUserFunctions(principal));
       return new Saml2AssertionAuthentication(
-          principal,
+          authentication, // Pass user details here
           authentication.getCredentials(),
           authorities,
           authentication.getRelyingPartyRegistrationId());
     };
   }
 
-  private Collection<? extends GrantedAuthority> getUserFunctions(String principal) {
+  private Collection<? extends GrantedAuthority> getUserFunctions(String loginId) {
     return userService
-        .getUserByLoginId(principal)
+        .getUserByLoginId(loginId)
         .blockOptional()
         .orElseThrow(() -> new RuntimeException("Failed to retrieve user functions."))
         .getFunctions()

--- a/src/main/java/uk/gov/laa/ccms/caab/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/config/SecurityConfiguration.java
@@ -152,7 +152,7 @@ public class SecurityConfiguration {
       String principal = authentication.getName();
       authorities.addAll(getUserFunctions(principal));
       return new Saml2AssertionAuthentication(
-          authentication, // Pass user details here
+          principal,
           authentication.getCredentials(),
           authorities,
           authentication.getRelyingPartyRegistrationId());

--- a/src/main/java/uk/gov/laa/ccms/caab/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/config/SecurityConfiguration.java
@@ -159,7 +159,7 @@ public class SecurityConfiguration {
 
   private Collection<? extends GrantedAuthority> getUserFunctions(String principal) {
     return userService
-        .getUser(principal)
+        .getUserByLoginId(principal)
         .blockOptional()
         .orElseThrow(() -> new RuntimeException("Failed to retrieve user functions."))
         .getFunctions()

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/HomeController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/HomeController.java
@@ -36,7 +36,7 @@ public class HomeController {
 
     // Retrieve a summary of the User's Notifications & Actions from the SOA Gateway
     NotificationSummary notificationSummary =
-        notificationService.getNotificationsSummary(user.getLoginId()).block();
+        notificationService.getNotificationsSummary(user.getUserId()).block();
 
     boolean showNotifications =
         notificationSummary != null && UserRoleUtil.hasRole(user, UserRole.VIEW_NOTIFICATIONS);

--- a/src/main/java/uk/gov/laa/ccms/caab/service/NotificationService.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/service/NotificationService.java
@@ -50,11 +50,11 @@ public class NotificationService {
   /**
    * Retrieve the summary of notifications for a given user.
    *
-   * @param loginId The login identifier for the user.
+   * @param userId The user identifier for the user.
    * @return A Mono wrapping the NotificationSummary for the specified user.
    */
-  public Mono<NotificationSummary> getNotificationsSummary(String loginId) {
-    return ebsApiClient.getUserNotificationSummary(loginId);
+  public Mono<NotificationSummary> getNotificationsSummary(Integer userId) {
+    return ebsApiClient.getUserNotificationSummary(userId);
   }
 
   /**

--- a/src/main/java/uk/gov/laa/ccms/caab/service/UserService.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/service/UserService.java
@@ -23,11 +23,11 @@ public class UserService {
   /**
    * Retrieves user details based on the login ID.
    *
-   * @param loginId The login ID of the user.
+   * @param userId The user ID of the user.
    * @return A Mono containing the UserDetail or an error handler if an error occurs.
    */
-  public Mono<UserDetail> getUser(String loginId) {
-    return ebsApiClient.getUser(loginId);
+  public Mono<UserDetail> getUser(Integer userId) {
+    return ebsApiClient.getUser(userId);
   }
 
   /**
@@ -53,5 +53,9 @@ public class UserService {
     UserOptions userOptions =
         new UserOptions().providerFirmId(String.valueOf(providerId)).userLoginId(loginId);
     return soaApiClient.updateUserOptions(userOptions, loginId, userType);
+  }
+
+  public Mono<UserDetail> getUserByLoginId(String loginId) {
+    return null;
   }
 }

--- a/src/main/java/uk/gov/laa/ccms/caab/service/UserService.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/service/UserService.java
@@ -23,6 +23,16 @@ public class UserService {
   /**
    * Retrieves user details based on the login ID.
    *
+   * @param loginId The login ID of the user.
+   * @return A Mono containing the UserDetail or an error handler if an error occurs.
+   */
+  public Mono<UserDetail> getUserByLoginId(String loginId) {
+    return ebsApiClient.getUserByLoginId(loginId);
+  }
+
+  /**
+   * Retrieves user details based on the login ID.
+   *
    * @param userId The user ID of the user.
    * @return A Mono containing the UserDetail or an error handler if an error occurs.
    */
@@ -53,9 +63,5 @@ public class UserService {
     UserOptions userOptions =
         new UserOptions().providerFirmId(String.valueOf(providerId)).userLoginId(loginId);
     return soaApiClient.updateUserOptions(userOptions, loginId, userType);
-  }
-
-  public Mono<UserDetail> getUserByLoginId(String loginId) {
-    return null;
   }
 }

--- a/src/test/java/uk/gov/laa/ccms/caab/client/EbsApiClientTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/client/EbsApiClientTest.java
@@ -84,18 +84,20 @@ public class EbsApiClientTest {
     @DisplayName("Should return data")
     void getUser_returnData() {
 
-      final String loginId = "user1";
-      final String expectedUri = "/users/{loginId}";
+      final Integer userId = 12345;
+      final String loginId = "foo";
+      final String expectedUri = "/users/{userId}";
 
       final UserDetail mockUser = new UserDetail();
+      mockUser.setUserId(userId);
       mockUser.setLoginId(loginId);
 
       when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-      when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
+      when(requestHeadersUriMock.uri(expectedUri, userId)).thenReturn(requestHeadersMock);
       when(requestHeadersMock.retrieve()).thenReturn(responseMock);
       when(responseMock.bodyToMono(UserDetail.class)).thenReturn(Mono.just(mockUser));
 
-      final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(loginId);
+      final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(userId);
 
       StepVerifier.create(userDetailsMono)
           .expectNextMatches(user -> user.getLoginId().equals(loginId))
@@ -105,11 +107,11 @@ public class EbsApiClientTest {
     @Test
     @DisplayName("Should return not found")
     void getUser_notFound() {
-      final String loginId = "user1";
-      final String expectedUri = "/users/{loginId}";
+      final Integer userId = 1;
+      final String expectedUri = "/users/{userId}";
 
       when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-      when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
+      when(requestHeadersUriMock.uri(expectedUri, userId)).thenReturn(requestHeadersMock);
       when(requestHeadersMock.retrieve()).thenReturn(responseMock);
       when(responseMock.bodyToMono(UserDetail.class))
           .thenReturn(
@@ -118,10 +120,10 @@ public class EbsApiClientTest {
                       HttpStatus.NOT_FOUND.value(), "", null, null, null)));
 
       when(apiClientErrorHandler.handleApiRetrieveError(
-              any(), eq("User"), eq("login id"), eq(loginId)))
+              any(), eq("User"), eq("user id"), eq(userId.toString())))
           .thenReturn(Mono.empty());
 
-      final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(loginId);
+      final Mono<UserDetail> userDetailsMono = ebsApiClient.getUser(userId);
 
       StepVerifier.create(userDetailsMono).verifyComplete();
     }
@@ -134,8 +136,9 @@ public class EbsApiClientTest {
     @Test
     @DisplayName("Should return not found")
     void getUserNotificationSummary_returnsData() {
+      final Integer userId = 1;
       final String loginId = "user1";
-      final String expectedUri = "/users/{loginId}/notifications/summary";
+      final String expectedUri = "/users/{userId}/notifications/summary";
 
       final NotificationSummary mockNotificationSummary = new NotificationSummary();
       mockNotificationSummary.setNotifications(1);
@@ -143,13 +146,13 @@ public class EbsApiClientTest {
       mockNotificationSummary.setOverdueActions(2);
 
       when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-      when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
+      when(requestHeadersUriMock.uri(expectedUri, userId)).thenReturn(requestHeadersMock);
       when(requestHeadersMock.retrieve()).thenReturn(responseMock);
       when(responseMock.bodyToMono(NotificationSummary.class))
           .thenReturn(Mono.just(mockNotificationSummary));
 
       final Mono<NotificationSummary> notificationSummary =
-          ebsApiClient.getUserNotificationSummary(loginId);
+          ebsApiClient.getUserNotificationSummary(userId);
 
       StepVerifier.create(notificationSummary)
           .expectNextMatches(
@@ -163,8 +166,8 @@ public class EbsApiClientTest {
     @Test
     @DisplayName("Should return data")
     void getUserNotificationSummary_NotFound() {
-      final String loginId = "user1";
-      final String expectedUri = "/users/{loginId}/notifications/summary";
+      final Integer userId = 12345;
+      final String expectedUri = "/users/{userId}/notifications/summary";
 
       final NotificationSummary mockNotificationSummary = new NotificationSummary();
       mockNotificationSummary.setNotifications(1);
@@ -172,13 +175,13 @@ public class EbsApiClientTest {
       mockNotificationSummary.setOverdueActions(2);
 
       when(webClientMock.get()).thenReturn(requestHeadersUriMock);
-      when(requestHeadersUriMock.uri(expectedUri, loginId)).thenReturn(requestHeadersMock);
+      when(requestHeadersUriMock.uri(expectedUri, userId)).thenReturn(requestHeadersMock);
       when(requestHeadersMock.retrieve()).thenReturn(responseMock);
       when(responseMock.bodyToMono(NotificationSummary.class))
           .thenReturn(Mono.just(mockNotificationSummary));
 
       final Mono<NotificationSummary> notificationSummary =
-          ebsApiClient.getUserNotificationSummary(loginId);
+          ebsApiClient.getUserNotificationSummary(userId);
 
       StepVerifier.create(notificationSummary)
           .expectNextMatches(

--- a/src/test/java/uk/gov/laa/ccms/caab/controller/HomeControllerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/controller/HomeControllerTest.java
@@ -97,7 +97,7 @@ public class HomeControllerTest {
             .overdueActions(overdueActions);
 
     // Mock the SOA Gateway service to return the notification summary
-    when(notificationService.getNotificationsSummary(userDetails.getLoginId()))
+    when(notificationService.getNotificationsSummary(userDetails.getUserId()))
         .thenReturn(Mono.just(notificationSummary));
 
     this.mockMvc
@@ -115,7 +115,7 @@ public class HomeControllerTest {
   public void testHomeHandlesNullNotifications() throws Exception {
 
     // Mock the SOA Gateway service to return the notification summary
-    when(notificationService.getNotificationsSummary(userDetails.getLoginId()))
+    when(notificationService.getNotificationsSummary(userDetails.getUserId()))
         .thenReturn(Mono.empty());
 
     this.mockMvc

--- a/src/test/java/uk/gov/laa/ccms/caab/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/service/NotificationServiceTest.java
@@ -59,14 +59,14 @@ class NotificationServiceTest {
   @Test
   void getNotificationsSummary_returnData() {
 
-    String loginId = "user1";
+    Integer userId = 12345;
 
     NotificationSummary mockSummary =
         new NotificationSummary().notifications(10).standardActions(5).overdueActions(2);
 
-    when(ebsApiClient.getUserNotificationSummary(loginId)).thenReturn(Mono.just(mockSummary));
+    when(ebsApiClient.getUserNotificationSummary(userId)).thenReturn(Mono.just(mockSummary));
 
-    Mono<NotificationSummary> summaryMono = notificationService.getNotificationsSummary(loginId);
+    Mono<NotificationSummary> summaryMono = notificationService.getNotificationsSummary(userId);
 
     StepVerifier.create(summaryMono)
         .expectNextMatches(

--- a/src/test/java/uk/gov/laa/ccms/caab/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/service/UserServiceTest.java
@@ -26,6 +26,23 @@ public class UserServiceTest {
   @InjectMocks private UserService userService;
 
   @Test
+  void getUserByLoginId_returnData() {
+    String loginId = "foo";
+
+    UserDetail mockUser = new UserDetail();
+    mockUser.setUserId(12345);
+    mockUser.setLoginId(loginId);
+
+    when(ebsApiClient.getUserByLoginId(loginId)).thenReturn(Mono.just(mockUser));
+
+    Mono<UserDetail> userDetailsMono = userService.getUserByLoginId(loginId);
+
+    StepVerifier.create(userDetailsMono)
+        .expectNextMatches(user -> user.getLoginId().equals(loginId))
+        .verifyComplete();
+  }
+
+  @Test
   void getUser_returnData() {
 
     Integer userId = 12345;

--- a/src/test/java/uk/gov/laa/ccms/caab/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/service/UserServiceTest.java
@@ -28,14 +28,16 @@ public class UserServiceTest {
   @Test
   void getUser_returnData() {
 
-    String loginId = "user1";
+    Integer userId = 12345;
+    String loginId = "foo";
 
     UserDetail mockUser = new UserDetail();
-    mockUser.setLoginId(loginId);
+    mockUser.setUserId(userId);
+    mockUser.setLoginId("foo");
 
-    when(ebsApiClient.getUser(loginId)).thenReturn(Mono.just(mockUser));
+    when(ebsApiClient.getUser(userId)).thenReturn(Mono.just(mockUser));
 
-    Mono<UserDetail> userDetailsMono = userService.getUser(loginId);
+    Mono<UserDetail> userDetailsMono = userService.getUser(userId);
 
     StepVerifier.create(userDetailsMono)
         .expectNextMatches(user -> user.getLoginId().equals(loginId))


### PR DESCRIPTION
### What

Changed the ui to pass user id to API's to avoid an issue with modsec rules being triggered when an email is passed.

### How to review

Main thing is the SamlPrincipleAdvice - it has principal name - not user id - so we may need a way to reverse lookup a user based on email still!

