### PR TITLE
Fix CSP and styling issues for OPA assessments

### DIFF
--- a/src/main/java/uk/gov/laa/ccms/caab/security/CspNonceFilter.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/security/CspNonceFilter.java
@@ -76,10 +76,12 @@ public class CspNonceFilter extends OncePerRequestFilter {
         + "; "
         + "style-src 'nonce-"
         + nonce
-        + "' 'self' "
+        + "' 'self' 'unsafe-inline' "
         + opaSources
         + "; "
-        + "img-src 'self' https://www.googletagmanager.com; "
+        + "img-src 'self' data: https://www.googletagmanager.com "
+        + opaSources
+        + "; "
         + "connect-src 'self' https://www.google-analytics.com "
         + opaSources
         + "; "

--- a/src/test/java/uk/gov/laa/ccms/caab/security/CspNonceFilterTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/security/CspNonceFilterTest.java
@@ -29,6 +29,8 @@ class CspNonceFilterTest {
             "https://opa.oraclecloud.com",
             "https://www.google-analytics.com",
             "frame-ancestors 'self'",
+            "style-src 'nonce-" + nonce + "' 'self' 'unsafe-inline' https://opa.oraclecloud.com",
+            "img-src 'self' data: https://www.googletagmanager.com https://opa.oraclecloud.com",
             "object-src 'none'",
             "base-uri 'self'",
             "form-action 'self'",


### PR DESCRIPTION
##What

Fix CSP and styling issues for OPA assessments

- Added 'unsafe-inline' to style-src in CspNonceFilter to support dynamic styling in Oracle's interviews.js.
- Added 'data:' and OPA origins to img-src to allow base64 images and OPA-hosted assets.
- Confirmed 'data:' is allowed in font-src for base64-encoded fonts.
- Linked 'moj.css' in assessment-get.html to resolve missing GOV.UK Frontend breakpoints.
- Updated unit tests to verify the comprehensive CSP policy.