### PR TITLE
Ensure ability to remove newly added organisation opponents

### DIFF
--- a/src/main/java/uk/gov/laa/ccms/caab/mapper/OpponentMapper.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/mapper/OpponentMapper.java
@@ -33,6 +33,7 @@ public interface OpponentMapper {
   @Mapping(target = "faxNumber", source = "organisation.contactDetails.fax")
   @Mapping(target = "emailAddress", source = "organisation.contactDetails.emailAddress")
   @Mapping(target = "shared", constant = "true")
+  @Mapping(target = "deletable", constant = "true")
   @Mapping(target = "type", ignore = true)
   OrganisationOpponentFormData toOrganisationOpponentFormData(
       OrganisationDetail organisation, CommonLookupValueDetail orgTypeLookup);

--- a/src/main/java/uk/gov/laa/ccms/caab/service/AmendmentService.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/service/AmendmentService.java
@@ -29,6 +29,7 @@ import uk.gov.laa.ccms.caab.model.ApplicationType;
 import uk.gov.laa.ccms.caab.model.BaseApplicationDetail;
 import uk.gov.laa.ccms.caab.model.CostLimitDetail;
 import uk.gov.laa.ccms.caab.model.IntDisplayValue;
+import uk.gov.laa.ccms.caab.model.OpponentDetail;
 import uk.gov.laa.ccms.caab.model.StringDisplayValue;
 import uk.gov.laa.ccms.caab.model.sections.ApplicationSectionDisplay;
 import uk.gov.laa.ccms.caab.util.AmendmentUtil;
@@ -308,11 +309,12 @@ public class AmendmentService {
     return amendmentSections.getOpponentsAndOtherParties().getOpponents().stream()
         .map(
             opponent -> {
+              OpponentDetail opponentDetail =
+                  OpponentUtil.getOpponentById(application, opponent.getId());
               AbstractOpponentFormData formData =
-                  applicationService.buildOpponentFormData(
-                      OpponentUtil.getOpponentById(application, opponent.getId()));
-              formData.setEditable(opponent.getEbsId() == null);
-              formData.setDeletable(opponent.getEbsId() == null);
+                  applicationService.buildOpponentFormData(opponentDetail);
+              formData.setEditable(Boolean.TRUE.equals(opponentDetail.getDeleteInd()));
+              formData.setDeletable(Boolean.TRUE.equals(opponentDetail.getDeleteInd()));
               return formData;
             })
         .toList();

--- a/src/main/java/uk/gov/laa/ccms/caab/service/AmendmentService.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/service/AmendmentService.java
@@ -313,7 +313,7 @@ public class AmendmentService {
                   OpponentUtil.getOpponentById(application, opponent.getId());
               AbstractOpponentFormData formData =
                   applicationService.buildOpponentFormData(opponentDetail);
-              formData.setEditable(Boolean.TRUE.equals(opponentDetail.getDeleteInd()));
+              formData.setEditable(true);
               formData.setDeletable(Boolean.TRUE.equals(opponentDetail.getDeleteInd()));
               return formData;
             })

--- a/src/main/java/uk/gov/laa/ccms/caab/service/ApplicationService.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/service/ApplicationService.java
@@ -1362,6 +1362,7 @@ public class ApplicationService {
 
     opponent.setAppMode(application.getAppMode());
     opponent.setAmendment(application.getAmendment());
+    opponent.setDeleteInd(true);
 
     caabApiClient.addOpponent(applicationId, opponent, userDetail.getLoginId()).block();
   }

--- a/src/test/java/uk/gov/laa/ccms/caab/mapper/OpponentMapperTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/mapper/OpponentMapperTest.java
@@ -47,6 +47,7 @@ public class OpponentMapperTest {
     assertEquals(orgTypeLookup.getDescription(), result.getOrganisationTypeDisplayValue());
     assertEquals(organisationDetail.getOtherInformation(), result.getOtherInformation());
     assertEquals(organisationDetail.getPartyId(), result.getPartyId());
+    org.junit.jupiter.api.Assertions.assertTrue(result.getDeletable());
   }
 
   @Test

--- a/src/test/java/uk/gov/laa/ccms/caab/service/ApplicationServiceTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/service/ApplicationServiceTest.java
@@ -1867,6 +1867,7 @@ class ApplicationServiceTest {
 
     assertEquals(application.getAppMode(), opponent.getAppMode());
     assertEquals(application.getAmendment(), opponent.getAmendment());
+    assertTrue(opponent.getDeleteInd());
   }
 
   @Test


### PR DESCRIPTION
### What

Fix: ensure 'Remove' button is visible for newly added organization opponents via search

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.