### PR TITLE
Cost Change Validation added to Allocate Cost Limit Review Page

### DIFF
--- a/src/main/java/uk/gov/laa/ccms/caab/bean/validators/costs/AllocateCostLimitValidator.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/validators/costs/AllocateCostLimitValidator.java
@@ -2,6 +2,7 @@ package uk.gov.laa.ccms.caab.bean.validators.costs;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.springframework.stereotype.Component;
@@ -93,6 +94,33 @@ public class AllocateCostLimitValidator extends AbstractValidator {
             "costEntries[" + (index == -1 ? 0 : index) + "].requestedCosts",
             "costCostAllocation.requestedAmount.belowBilledAmount");
       }
+    }
+  }
+
+  public void validateCostsHaveBeenUpdated(
+      List<CostEntryDetail> updatedCosts, List<CostEntryDetail> existingCosts, Errors errors) {
+    boolean hasCostsBeenUpdated = false;
+    for (CostEntryDetail updatedCost : updatedCosts) {
+      CostEntryDetail existingCost =
+          existingCosts.stream()
+              .filter(
+                  c -> {
+                    if (updatedCost.getLscResourceId() != null) {
+                      return Objects.equals(c.getLscResourceId(), updatedCost.getLscResourceId());
+                    }
+                    return Objects.equals(c.getResourceName(), updatedCost.getResourceName());
+                  })
+              .findFirst()
+              .orElse(null);
+
+      if (existingCost == null
+          || existingCost.getRequestedCosts().compareTo(updatedCost.getRequestedCosts()) != 0) {
+        hasCostsBeenUpdated = true;
+        break;
+      }
+    }
+    if (!hasCostsBeenUpdated) {
+      errors.reject("costCostAllocation.requestedAmount.unchangedAmount");
     }
   }
 }

--- a/src/main/java/uk/gov/laa/ccms/caab/bean/validators/costs/AllocateCostLimitValidator.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/validators/costs/AllocateCostLimitValidator.java
@@ -114,7 +114,7 @@ public class AllocateCostLimitValidator extends AbstractValidator {
               .orElse(null);
 
       if (existingCost == null
-          || existingCost.getRequestedCosts().compareTo(updatedCost.getRequestedCosts()) != 0) {
+          || !Objects.equals(existingCost.getRequestedCosts(), updatedCost.getRequestedCosts())) {
         hasCostsBeenUpdated = true;
         break;
       }

--- a/src/main/java/uk/gov/laa/ccms/caab/constants/SessionConstants.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/constants/SessionConstants.java
@@ -223,6 +223,9 @@ public class SessionConstants {
   /** Session attribute used to store the cost allocation flow form data. */
   public static final String COST_ALLOCATION_FORM_DATA = "costAllocationFormData";
 
+  /** Session attribute used to keep track of existing cost allocations. */
+  public static final String COST_ALLOCATION_CASE_COST_ENTRIES = "costAllocationCaseCostEntries";
+
   /** Session attribute for keeping track of counsel search criteria. */
   public static final String COUNSEL_SEARCH_CRITERIA = "counselSearchCriteria";
 

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/AllocateCostLimitController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/AllocateCostLimitController.java
@@ -2,6 +2,7 @@ package uk.gov.laa.ccms.caab.controller.application;
 
 import static uk.gov.laa.ccms.caab.constants.SessionConstants.ACTIVE_CASE;
 import static uk.gov.laa.ccms.caab.constants.SessionConstants.CASE;
+import static uk.gov.laa.ccms.caab.constants.SessionConstants.COST_ALLOCATION_CASE_COST_ENTRIES;
 import static uk.gov.laa.ccms.caab.constants.SessionConstants.COST_ALLOCATION_FORM_DATA;
 import static uk.gov.laa.ccms.caab.constants.SessionConstants.SUBMISSION_RESULT;
 import static uk.gov.laa.ccms.caab.constants.SessionConstants.SUBMISSION_TRANSACTION_ID;
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -74,6 +76,10 @@ public class AllocateCostLimitController {
 
       // Update only the costs to avoid overwriting session-scoped metadata like availableFunctions.
       ebsCase.setCosts(freshCase.getCosts());
+
+      List<CostEntryDetail> existingCosts =
+          freshCase.getCosts().getCostEntries().stream().distinct().collect(Collectors.toList());
+      session.setAttribute(COST_ALLOCATION_CASE_COST_ENTRIES, existingCosts);
 
       allocateCostsFormData = proceedingAndCostsMapper.toAllocateCostsForm(ebsCase);
       session.setAttribute(COST_ALLOCATION_FORM_DATA, allocateCostsFormData);
@@ -220,9 +226,28 @@ public class AllocateCostLimitController {
   public String submitCaseCosts(
       @SessionAttribute(ACTIVE_CASE) final ActiveCase activeCase,
       @SessionAttribute(USER_DETAILS) final UserDetail userDetail,
-      @SessionAttribute(COST_ALLOCATION_FORM_DATA)
-          final AllocateCostsFormData allocateCostsFormData,
+      @SessionAttribute(CASE) final ApplicationDetail ebsCase,
+      @SessionAttribute(COST_ALLOCATION_FORM_DATA) AllocateCostsFormData allocateCostsFormData,
+      @SessionAttribute(COST_ALLOCATION_CASE_COST_ENTRIES)
+          final List<CostEntryDetail> existingCosts,
+      final Model model,
       final HttpSession session) {
+
+    List<CostEntryDetail> updatedCosts =
+        ebsCase.getCosts().getCostEntries().stream().distinct().collect(Collectors.toList());
+
+    final BindingResult bindingResult =
+        new BeanPropertyBindingResult(allocateCostsFormData, COST_ALLOCATION_FORM_DATA);
+
+    allocateCostLimitValidator.validateCostsHaveBeenUpdated(
+        updatedCosts, existingCosts, bindingResult);
+
+    if (bindingResult.hasErrors()) {
+      model.addAttribute("costDetails", allocateCostsFormData);
+      model.addAttribute("case", ebsCase);
+      model.addAttribute(BindingResult.MODEL_KEY_PREFIX + "costDetails", bindingResult);
+      return "application/case-costs-review";
+    }
 
     final String transactionId =
         amendmentService.submitQuickAmendmentCostAllocation(

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1073,6 +1073,8 @@ costCostAllocation.exceeded.requestedCost=You have exceeded the granted cost lim
    for the Case. Please review and amend your cost limit allocations.
 costCostAllocation.empty.error=
 costCostAllocation.requestedAmount.nullAmount=Enter a requested amount
+costCostAllocation.requestedAmount.unchangedAmount=You have not made any changes to the cost \
+  limitations. Please make a change before continuing.
 
 
 notificationSearchCriteria.caseReference=LAA application / case reference

--- a/src/main/resources/templates/application/case-costs-review.html
+++ b/src/main/resources/templates/application/case-costs-review.html
@@ -16,6 +16,7 @@
         <p class="govuk-body-l" th:text="#{caseCosts.review.leadParagraph}"></p>
 
         <form th:action="@{/allocate-cost-limit/review}" th:object="${costDetails}" method="post">
+            <div th:replace="~{partials/error-summary :: error-summary}"></div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <table class="govuk-table">

--- a/src/test/java/uk/gov/laa/ccms/caab/controller/application/AllocateCostLimitControllerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/controller/application/AllocateCostLimitControllerTest.java
@@ -1,19 +1,11 @@
 package uk.gov.laa.ccms.caab.controller.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static uk.gov.laa.ccms.caab.constants.SessionConstants.ACTIVE_CASE;
-import static uk.gov.laa.ccms.caab.constants.SessionConstants.CASE;
-import static uk.gov.laa.ccms.caab.constants.SessionConstants.COST_ALLOCATION_FORM_DATA;
-import static uk.gov.laa.ccms.caab.constants.SessionConstants.USER_DETAILS;
+import static uk.gov.laa.ccms.caab.constants.SessionConstants.*;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -600,7 +592,6 @@ public class AllocateCostLimitControllerTest {
           new CostStructureDetail()
               .addCostEntriesItem(
                   new CostEntryDetail()
-                      .requestedCosts(new BigDecimal("2250"))
                       .resourceName("PATRICK J BOWE")
                       .costCategory("Counsel")
                       .amountBilled(new BigDecimal("604.63"))
@@ -611,6 +602,14 @@ public class AllocateCostLimitControllerTest {
       ebsCase.setProviderDetails(
           new ApplicationProviderDetails()
               .provider(new IntDisplayValue().displayValue("provider")));
+
+      List<CostEntryDetail> existingCosts =
+          List.of(
+              new CostEntryDetail()
+                  .requestedCosts(new BigDecimal("2000"))
+                  .resourceName("PATRICK J BOWE")
+                  .costCategory("Counsel")
+                  .amountBilled(new BigDecimal("604.63")));
 
       AllocateCostsFormData formData = new AllocateCostsFormData();
       formData.setRequestedCostLimitation(new BigDecimal("25000"));
@@ -626,12 +625,77 @@ public class AllocateCostLimitControllerTest {
                       .sessionAttr(CASE, ebsCase)
                       .sessionAttr(USER_DETAILS, user)
                       .sessionAttr(ACTIVE_CASE, activeCase)
-                      .sessionAttr(COST_ALLOCATION_FORM_DATA, formData)))
+                      .sessionAttr(COST_ALLOCATION_FORM_DATA, formData)
+                      .sessionAttr(COST_ALLOCATION_CASE_COST_ENTRIES, existingCosts)))
           .hasRedirectedUrl("/amendments/submit-case");
 
       // The costs held in session are submitted as-is, so the requested cost limitation and each
       // entry's EBS id survive the review step.
       verify(amendmentService).submitQuickAmendmentCostAllocation(formData, "CASE123", user);
     }
+  }
+
+  @Test
+  @DisplayName(
+      "Should return cost allocation review view and not update session when submit clicked with validation errors")
+  void shouldReturnViewWhenSubmitHasValidationErrors() {
+    ApplicationDetail ebsCase = new ApplicationDetail();
+    UserDetail user = new UserDetail();
+    user.setProvider(new BaseProvider());
+    user.getProvider().setId(123);
+    ActiveCase activeCase = ActiveCase.builder().caseReferenceNumber("CASE123").build();
+    ebsCase.caseReferenceNumber("123456");
+    CostStructureDetail costs =
+        new CostStructureDetail()
+            .addCostEntriesItem(
+                new CostEntryDetail()
+                    .resourceName("PATRICK J BOWE")
+                    .costCategory("Counsel")
+                    .amountBilled(new BigDecimal("604.63"))
+                    .requestedCosts(new BigDecimal("604.63")))
+            .grantedCostLimitation(new BigDecimal("25000"))
+            .requestedCostLimitation(new BigDecimal("25000"));
+    ebsCase.setCosts(costs);
+    ebsCase.setProviderDetails(
+        new ApplicationProviderDetails().provider(new IntDisplayValue().displayValue("provider")));
+
+    List<CostEntryDetail> existingCosts =
+        List.of(
+            new CostEntryDetail()
+                .requestedCosts(new BigDecimal("604.63"))
+                .resourceName("PATRICK J BOWE")
+                .costCategory("Counsel")
+                .amountBilled(new BigDecimal("604.63")));
+
+    AllocateCostsFormData formData = new AllocateCostsFormData();
+    formData.setRequestedCostLimitation(new BigDecimal("25000"));
+    formData.setGrantedCostLimitation(new BigDecimal("25000"));
+    formData.setCostEntries(costs.getCostEntries());
+
+    // Mock validator to add an error
+    doAnswer(
+            invocation -> {
+              org.springframework.validation.Errors errors = invocation.getArgument(2);
+              errors.reject("costCostAllocation.requestedAmount.unchangedAmount");
+              return null;
+            })
+        .when(allocateCostLimitValidator)
+        .validateCostsHaveBeenUpdated(
+            anyList(), anyList(), any(org.springframework.validation.Errors.class));
+
+    assertThat(
+            mockMvc.perform(
+                post("/allocate-cost-limit/review")
+                    .sessionAttr(CASE, ebsCase)
+                    .sessionAttr(USER_DETAILS, user)
+                    .sessionAttr(ACTIVE_CASE, activeCase)
+                    .sessionAttr(COST_ALLOCATION_FORM_DATA, formData)
+                    .sessionAttr(COST_ALLOCATION_CASE_COST_ENTRIES, existingCosts)))
+        .hasStatusOk()
+        .hasViewName("application/case-costs-review")
+        .model()
+        .containsEntry("case", ebsCase)
+        .containsEntry("costDetails", formData)
+        .containsKey("org.springframework.validation.BindingResult.costDetails");
   }
 }

--- a/src/test/java/uk/gov/laa/ccms/caab/controller/application/AllocateCostLimitControllerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/controller/application/AllocateCostLimitControllerTest.java
@@ -1,11 +1,21 @@
 package uk.gov.laa.ccms.caab.controller.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static uk.gov.laa.ccms.caab.constants.SessionConstants.*;
+import static uk.gov.laa.ccms.caab.constants.SessionConstants.ACTIVE_CASE;
+import static uk.gov.laa.ccms.caab.constants.SessionConstants.CASE;
+import static uk.gov.laa.ccms.caab.constants.SessionConstants.COST_ALLOCATION_CASE_COST_ENTRIES;
+import static uk.gov.laa.ccms.caab.constants.SessionConstants.COST_ALLOCATION_FORM_DATA;
+import static uk.gov.laa.ccms.caab.constants.SessionConstants.USER_DETAILS;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;


### PR DESCRIPTION
### What

Validation added to check that the user has made a change to the allocated costs before submitting, preventing needless submits being sent with the same data that's already saved

### How to review

Go through the allocate costs flow without making any modifications and you get a validation error, and if you make any change it progresses as normal and submits.

### Who can review

Anyone