### PR TITLE
Update Netty Version to resolve Snyk Failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,15 @@ dependencies {
 
     }
 
+    // Fixes CVE-2026-55831 - remove this when bumped in parent library:
+    // org.springframework.boot:spring-boot-starter-webflux
+    implementation 'io.netty:netty-codec:4.2.16.Final'
+    implementation 'io.netty:netty-codec-compression:4.2.16.Final'
+    implementation 'io.netty:netty-codec-dns:4.2.16.Final'
+    implementation 'io.netty:netty-codec-http:4.2.16.Final'
+    implementation 'io.netty:netty-codec-http2:4.2.16.Final'
+    implementation 'io.netty:netty-codec-http3:4.2.16.Final'
+    
     // Fixes CVE-2025-48924 - remove this when bumped in parent library
     implementation 'org.apache.commons:commons-lang3:3.20.0'
 


### PR DESCRIPTION
### What

Added dependency overwrites for Netty to resolve Snyk Vulnerability Scan failures until parent dependency is updated

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.