### PR TITLE
CCMSPUI-1042: Clear Organisation Search Criteria on load of Opponents…

### DIFF
--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionController.java
@@ -110,16 +110,10 @@ public class OpponentsSectionController {
       @PathVariable(value = "caseContext", required = false) final CaseContext caseContext,
       @SessionAttribute(value = APPLICATION_ID, required = false) final String applicationId,
       @SessionAttribute(value = USER_DETAILS, required = false) final UserDetail user,
-      @ModelAttribute(ORGANISATION_SEARCH_CRITERIA) final OrganisationSearchCriteria searchCriteria,
       final HttpServletRequest request,
       final Model model) {
 
-    if (searchCriteria.getName() != null
-        || searchCriteria.getType() != null
-        || searchCriteria.getCity() != null
-        || searchCriteria.getPostcode() != null) {
-      model.addAttribute(ORGANISATION_SEARCH_CRITERIA, new OrganisationSearchCriteria());
-    }
+    model.addAttribute(ORGANISATION_SEARCH_CRITERIA, new OrganisationSearchCriteria());
 
     CaseContext resolvedCaseContext = resolveCaseContext(caseContext, request);
     addCaseContext(model, resolvedCaseContext);

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionController.java
@@ -114,12 +114,10 @@ public class OpponentsSectionController {
       final HttpServletRequest request,
       final Model model) {
 
-    if (Stream.of(
-            searchCriteria.getName(),
-            searchCriteria.getType(),
-            searchCriteria.getCity(),
-            searchCriteria.getPostcode())
-        .anyMatch(Objects::nonNull)) {
+    if (searchCriteria.getName() != null
+        || searchCriteria.getType() != null
+        || searchCriteria.getCity() != null
+        || searchCriteria.getPostcode() != null) {
       model.addAttribute(ORGANISATION_SEARCH_CRITERIA, new OrganisationSearchCriteria());
     }
 

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionController.java
@@ -12,6 +12,8 @@ import static uk.gov.laa.ccms.caab.constants.SessionConstants.USER_DETAILS;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.propertyeditors.StringTrimmerEditor;
@@ -110,8 +112,18 @@ public class OpponentsSectionController {
       @PathVariable(value = "caseContext", required = false) final CaseContext caseContext,
       @SessionAttribute(value = APPLICATION_ID, required = false) final String applicationId,
       @SessionAttribute(value = USER_DETAILS, required = false) final UserDetail user,
+      @ModelAttribute(ORGANISATION_SEARCH_CRITERIA) final OrganisationSearchCriteria searchCriteria,
       final HttpServletRequest request,
       final Model model) {
+
+    if (Stream.of(
+            searchCriteria.getName(),
+            searchCriteria.getType(),
+            searchCriteria.getCity(),
+            searchCriteria.getPostcode())
+        .anyMatch(Objects::nonNull)) {
+      model.addAttribute(ORGANISATION_SEARCH_CRITERIA, new OrganisationSearchCriteria());
+    }
 
     CaseContext resolvedCaseContext = resolveCaseContext(caseContext, request);
     addCaseContext(model, resolvedCaseContext);

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionController.java
@@ -12,8 +12,6 @@ import static uk.gov.laa.ccms.caab.constants.SessionConstants.USER_DETAILS;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.propertyeditors.StringTrimmerEditor;

--- a/src/test/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionControllerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionControllerTest.java
@@ -136,7 +136,7 @@ class OpponentsSectionControllerTest {
 
     OrganisationSearchCriteria resultSearchCriteria =
         (OrganisationSearchCriteria)
-            result.getModelAndView().getModel().get(ORGANISATION_SEARCH_CRITERIA);
+            result.getRequest().getSession().getAttribute(ORGANISATION_SEARCH_CRITERIA);
     assertNull(resultSearchCriteria.getName());
     assertNull(resultSearchCriteria.getType());
     assertNull(resultSearchCriteria.getCity());

--- a/src/test/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionControllerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.laa.ccms.caab.controller.application.section;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -39,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.Errors;
 import org.springframework.web.context.WebApplicationContext;
@@ -111,6 +113,34 @@ class OpponentsSectionControllerTest {
         .perform(get("/application/sections/opponents").sessionAttr("applicationId", "123"))
         .andExpect(status().isOk())
         .andExpect(view().name("application/sections/opponents-section"));
+  }
+
+  @Test
+  void opponents_clearsOrganisationSearchCriteria() throws Exception {
+    OrganisationSearchCriteria searchCriteria = new OrganisationSearchCriteria();
+    searchCriteria.setName("Test Organisation Name");
+    searchCriteria.setType("NHS");
+    searchCriteria.setCity("London");
+    searchCriteria.setPostcode("SW1A 0AA");
+    when(applicationService.getOpponents(any())).thenReturn(new ArrayList<>());
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/application/sections/opponents")
+                    .sessionAttr("applicationId", "123")
+                    .sessionAttr(ORGANISATION_SEARCH_CRITERIA, searchCriteria))
+            .andExpect(status().isOk())
+            .andExpect(view().name("application/sections/opponents-section"))
+            .andReturn();
+
+    OrganisationSearchCriteria resultSearchCriteria =
+        (OrganisationSearchCriteria)
+            result.getModelAndView().getModel().get(ORGANISATION_SEARCH_CRITERIA);
+    assertNull(resultSearchCriteria.getName());
+    assertNull(resultSearchCriteria.getType());
+    assertNull(resultSearchCriteria.getCity());
+    assertNull(resultSearchCriteria.getPostcode());
   }
 
   @Test


### PR DESCRIPTION
… main page

### What

Clear Organisation Search Criteria on load of Opponent section landing page to prevent search criteria persisting across applications

### How to review

Enter Opponents section and search for an organisation, navigate to the main opponents landing page then proceed to the organisation search page to see that the previously entered search criteria is no longer there

### Who can review

Describe who worked on the changes, so that other people can review.