### PR TITLE
fix: add missing closing quote to bootRun command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The application can be run in one of the following ways. As above, add `secret` 
 #### Terminal
 
 ```shell
-./gradlew bootRun --args='--spring.profiles.active=local
+./gradlew bootRun --args='--spring.profiles.active=local'
 ```
 
 #### IntelliJ


### PR DESCRIPTION
### What
Fixed missing closing quote in the bootRun terminal command in README.md.

### How to review
Check the README terminal command now reads:
`./gradlew bootRun --args='--spring.profiles.active=local'`

### Who can review
Anyone on the team.