### PR TITLE
CCMSPUI-1074: Validate date format on client search to prevent system error

### DIFF
--- a/src/main/java/uk/gov/laa/ccms/caab/bean/validators/AbstractValidator.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/validators/AbstractValidator.java
@@ -284,22 +284,8 @@ public abstract class AbstractValidator implements Validator {
    *
    * @param target The object to be validated.
    * @param errors The Errors object to store validation errors.
-   * @param required Whether date of birth is required.
    */
   public void validateDateOfBirth(Object target, Errors errors, boolean required) {
-    validateDateOfBirth(target, errors, required, COMPONENT_DATE_PATTERN);
-  }
-
-  /**
-   * Validates the date of birth of the {@link Individual} against the supplied date pattern.
-   *
-   * @param target The object to be validated.
-   * @param errors The Errors object to store validation errors.
-   * @param required Whether date of birth is required.
-   * @param datePattern The expected date format pattern (e.g. "d/M/yyyy" or "yyyy-MM-dd").
-   */
-  public void validateDateOfBirth(
-      Object target, Errors errors, boolean required, String datePattern) {
     if (required) {
       ValidationUtils.rejectIfEmpty(
           errors, "dateOfBirth", "required.dob", "Please complete 'Date of birth'");
@@ -309,7 +295,11 @@ public abstract class AbstractValidator implements Validator {
 
     if (individual.getDateOfBirth() != null && !individual.getDateOfBirth().isBlank()) {
       validateValidDateField(
-          individual.getDateOfBirth(), "dateOfBirth", "Date of birth", datePattern, errors);
+          individual.getDateOfBirth(),
+          "dateOfBirth",
+          "Date of birth",
+          COMPONENT_DATE_PATTERN,
+          errors);
       if (!errors.hasFieldErrors("dateOfBirth")) {
         try {
           validateDateInPast(

--- a/src/main/java/uk/gov/laa/ccms/caab/bean/validators/AbstractValidator.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/validators/AbstractValidator.java
@@ -44,6 +44,9 @@ public abstract class AbstractValidator implements Validator {
   protected static String GENERIC_MISSING_DATE_FIELDS_FORMAT =
       "Your input for '%s' is incomplete. Please enter a value for day, month and year.";
 
+  protected static final String SPECIFIC_DATEFIELD_ENTRY =
+      "Your input for '%s' is invalid. Please enter the date in DD/MM/YYYY format.";
+
   protected static String GENERIC_FIRST_CHAR_ALPHA =
       "Your input for %s is invalid. "
           + "The first character must be a letter. Please amend your entry.";
@@ -281,8 +284,22 @@ public abstract class AbstractValidator implements Validator {
    *
    * @param target The object to be validated.
    * @param errors The Errors object to store validation errors.
+   * @param required Whether date of birth is required.
    */
   public void validateDateOfBirth(Object target, Errors errors, boolean required) {
+    validateDateOfBirth(target, errors, required, COMPONENT_DATE_PATTERN);
+  }
+
+  /**
+   * Validates the date of birth of the {@link Individual} against the supplied date pattern.
+   *
+   * @param target The object to be validated.
+   * @param errors The Errors object to store validation errors.
+   * @param required Whether date of birth is required.
+   * @param datePattern The expected date format pattern (e.g. "d/M/yyyy" or "yyyy-MM-dd").
+   */
+  public void validateDateOfBirth(
+      Object target, Errors errors, boolean required, String datePattern) {
     if (required) {
       ValidationUtils.rejectIfEmpty(
           errors, "dateOfBirth", "required.dob", "Please complete 'Date of birth'");
@@ -292,18 +309,14 @@ public abstract class AbstractValidator implements Validator {
 
     if (individual.getDateOfBirth() != null && !individual.getDateOfBirth().isBlank()) {
       validateValidDateField(
-          individual.getDateOfBirth(),
-          "dateOfBirth",
-          "Date of birth",
-          COMPONENT_DATE_PATTERN,
-          errors);
+          individual.getDateOfBirth(), "dateOfBirth", "Date of birth", datePattern, errors);
       if (!errors.hasFieldErrors("dateOfBirth")) {
         try {
           validateDateInPast(
               convertToDate(individual.getDateOfBirth()), "dateOfBirth", "Date of birth", errors);
         } catch (java.time.format.DateTimeParseException ex) {
           errors.rejectValue(
-              "dateOfBirth", "invalid.input", GENERIC_DATEFIELD_ENTRY.formatted("Date of birth"));
+              "dateOfBirth", "invalid.input", SPECIFIC_DATEFIELD_ENTRY.formatted("Date of birth"));
         }
       }
     }

--- a/src/main/java/uk/gov/laa/ccms/caab/bean/validators/AbstractValidator.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/validators/AbstractValidator.java
@@ -306,7 +306,7 @@ public abstract class AbstractValidator implements Validator {
               convertToDate(individual.getDateOfBirth()), "dateOfBirth", "Date of birth", errors);
         } catch (java.time.format.DateTimeParseException ex) {
           errors.rejectValue(
-              "dateOfBirth", "invalid.input", SPECIFIC_DATEFIELD_ENTRY.formatted("Date of birth"));
+              "dateOfBirth", "invalid.format", SPECIFIC_DATEFIELD_ENTRY.formatted("Date of birth"));
         }
       }
     }

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/ClientSearchCriteriaValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/ClientSearchCriteriaValidatorTest.java
@@ -3,11 +3,13 @@ package uk.gov.laa.ccms.caab.bean;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.laa.ccms.caab.constants.UniqueIdentifierTypeConstants.UNIQUE_IDENTIFIER_CASE_REFERENCE_NUMBER;
 import static uk.gov.laa.ccms.caab.constants.UniqueIdentifierTypeConstants.UNIQUE_IDENTIFIER_HOME_OFFICE_REFERENCE;
 import static uk.gov.laa.ccms.caab.constants.UniqueIdentifierTypeConstants.UNIQUE_IDENTIFIER_NATIONAL_INSURANCE_NUMBER;
 
+import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -115,31 +117,30 @@ class ClientSearchCriteriaValidatorTest {
     assertEquals(1, errors.getErrorCount());
   }
 
-  @Test
-  void testValidateDateOfBirth_Valid() {
-    clientSearchCriteria.setDateOfBirth("01/12/1990");
-    validator.validateDateOfBirth(clientSearchCriteria, errors, true);
-    assertFalse(errors.hasErrors());
-  }
-
-  @Test
-  void testValidateDateOfBirth_Invalid() {
-    clientSearchCriteria.setDateOfBirth("");
-    validator.validateDateOfBirth(clientSearchCriteria, errors, true);
-    assertTrue(errors.hasErrors());
-    assertNotNull(errors.getFieldError("dateOfBirth"));
-    assertEquals("required.dob", errors.getFieldError("dateOfBirth").getCode());
-  }
-
   @ParameterizedTest
-  @CsvSource({"abc/12/1990, dateOfBirth", "1/ab/1990, dateOfBirth", "1/12/abcd, dateOfBirth"})
-  void testValidateDateOfBirth_InvalidNumeric(String dobDay, String field) {
-    clientSearchCriteria.setDateOfBirth(dobDay);
+  @CsvSource({
+    "1/12/1990, ''",
+    "01/01/2000, ''",
+    "1/12/2099, invalid.input",
+    "'', required.dob",
+    "abc-12-1990, invalid.format",
+    "1-ab-1990, invalid.format",
+    "1-12-abcd, invalid.format"
+  })
+  void testValidateDateOfBirth_VariousValues(String dateOfBirth, String expectedErrorCode) {
+    clientSearchCriteria.setDateOfBirth(dateOfBirth);
 
-    validator.validateDateOfBirth(clientSearchCriteria, errors, true);
-    assertTrue(errors.hasErrors());
-    assertNotNull(errors.getFieldError(field));
-    assertEquals("invalid.format", errors.getFieldError(field).getCode());
+    validator.validateDateOfBirth(clientSearchCriteria, errors, true, "d/M/yyyy");
+
+    if (expectedErrorCode.isBlank()) {
+      assertFalse(errors.hasErrors());
+      assertNull(errors.getFieldError("dateOfBirth"));
+    } else {
+      assertTrue(errors.hasErrors());
+      assertNotNull(errors.getFieldError("dateOfBirth"));
+      assertEquals(
+          expectedErrorCode, Objects.requireNonNull(errors.getFieldError("dateOfBirth")).getCode());
+    }
   }
 
   @ParameterizedTest
@@ -160,7 +161,8 @@ class ClientSearchCriteriaValidatorTest {
     assertTrue(errors.hasErrors());
     assertNotNull(errors.getFieldError("uniqueIdentifierValue"));
     assertEquals(
-        "invalid.uniqueIdentifierValue", errors.getFieldError("uniqueIdentifierValue").getCode());
+        "invalid.uniqueIdentifierValue",
+        Objects.requireNonNull(errors.getFieldError("uniqueIdentifierValue")).getCode());
   }
 
   @ParameterizedTest
@@ -191,7 +193,7 @@ class ClientSearchCriteriaValidatorTest {
   void testValidate_Valid() {
     clientSearchCriteria.setForename("John");
     clientSearchCriteria.setSurname("Doe");
-    clientSearchCriteria.setDateOfBirth("01/12/1990");
+    clientSearchCriteria.setDateOfBirth("1/12/1990");
     clientSearchCriteria.setUniqueIdentifierType(1);
     clientSearchCriteria.setUniqueIdentifierValue("AB123456C");
     validator.validate(clientSearchCriteria, errors);
@@ -201,11 +203,11 @@ class ClientSearchCriteriaValidatorTest {
   @ParameterizedTest
   @CsvSource({
     "'','','', 3",
-    "'',Doe,12/1990,2",
-    "John,'',12/1990,2",
+    "'',Doe,12-1990,2",
+    "John,'',12-1990,2",
     "John,Doe,1990,1",
-    "John,Doe,1/1990,1",
-    "John,Doe,1/12/,1",
+    "John,Doe,1-1990,1",
+    "John,Doe,1-12-,1",
   })
   void testValidate_Invalid(
       String forename, String surname, String dobDay, int expectedErrorCount) {

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/ClientSearchCriteriaValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/ClientSearchCriteriaValidatorTest.java
@@ -51,7 +51,8 @@ class ClientSearchCriteriaValidatorTest {
     validator.validateForename(clientSearchCriteria, errors);
     assertTrue(errors.hasErrors());
     assertNotNull(errors.getFieldError("forename"));
-    assertEquals("required.forename", errors.getFieldError("forename").getCode());
+    assertEquals(
+        "required.forename", Objects.requireNonNull(errors.getFieldError("forename")).getCode());
   }
 
   @Test
@@ -90,7 +91,8 @@ class ClientSearchCriteriaValidatorTest {
     validator.validateSurnameAtBirth(clientSearchCriteria, errors);
     assertTrue(errors.hasErrors());
     assertNotNull(errors.getFieldError("surname"));
-    assertEquals("required.surname", errors.getFieldError("surname").getCode());
+    assertEquals(
+        "required.surname", Objects.requireNonNull(errors.getFieldError("surname")).getCode());
   }
 
   @Test
@@ -125,12 +127,13 @@ class ClientSearchCriteriaValidatorTest {
     "'', required.dob",
     "abc-12-1990, invalid.format",
     "1-ab-1990, invalid.format",
-    "1-12-abcd, invalid.format"
+    "1-12-abcd, invalid.format",
+    "4/3/07, invalid.input",
   })
   void testValidateDateOfBirth_VariousValues(String dateOfBirth, String expectedErrorCode) {
     clientSearchCriteria.setDateOfBirth(dateOfBirth);
 
-    validator.validateDateOfBirth(clientSearchCriteria, errors, true, "d/M/yyyy");
+    validator.validateDateOfBirth(clientSearchCriteria, errors, true);
 
     if (expectedErrorCode.isBlank()) {
       assertFalse(errors.hasErrors());
@@ -174,7 +177,8 @@ class ClientSearchCriteriaValidatorTest {
     assertTrue(errors.hasErrors());
     assertNotNull(errors.getFieldError("uniqueIdentifierValue"));
     assertEquals(
-        "invalid.uniqueIdentifierValue", errors.getFieldError("uniqueIdentifierValue").getCode());
+        "invalid.uniqueIdentifierValue",
+        Objects.requireNonNull(errors.getFieldError("uniqueIdentifierValue")).getCode());
   }
 
   @ParameterizedTest
@@ -186,14 +190,15 @@ class ClientSearchCriteriaValidatorTest {
     assertTrue(errors.hasErrors());
     assertNotNull(errors.getFieldError("uniqueIdentifierValue"));
     assertEquals(
-        "invalid.uniqueIdentifierValue", errors.getFieldError("uniqueIdentifierValue").getCode());
+        "invalid.uniqueIdentifierValue",
+        Objects.requireNonNull(errors.getFieldError("uniqueIdentifierValue")).getCode());
   }
 
   @Test
   void testValidate_Valid() {
     clientSearchCriteria.setForename("John");
     clientSearchCriteria.setSurname("Doe");
-    clientSearchCriteria.setDateOfBirth("1/12/1990");
+    clientSearchCriteria.setDateOfBirth("01/12/1990");
     clientSearchCriteria.setUniqueIdentifierType(1);
     clientSearchCriteria.setUniqueIdentifierValue("AB123456C");
     validator.validate(clientSearchCriteria, errors);
@@ -203,11 +208,11 @@ class ClientSearchCriteriaValidatorTest {
   @ParameterizedTest
   @CsvSource({
     "'','','', 3",
-    "'',Doe,12-1990,2",
-    "John,'',12-1990,2",
+    "'',Doe,12/1990,2",
+    "John,'',12/1990,2",
     "John,Doe,1990,1",
-    "John,Doe,1-1990,1",
-    "John,Doe,1-12-,1",
+    "John,Doe,1/1990,1",
+    "John,Doe,1/12/,1",
   })
   void testValidate_Invalid(
       String forename, String surname, String dobDay, int expectedErrorCount) {

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/ClientSearchCriteriaValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/ClientSearchCriteriaValidatorTest.java
@@ -128,7 +128,7 @@ class ClientSearchCriteriaValidatorTest {
     "abc-12-1990, invalid.format",
     "1-ab-1990, invalid.format",
     "1-12-abcd, invalid.format",
-    "4/3/07, invalid.input",
+    "4/3/07, invalid.format",
   })
   void testValidateDateOfBirth_VariousValues(String dateOfBirth, String expectedErrorCode) {
     clientSearchCriteria.setDateOfBirth(dateOfBirth);


### PR DESCRIPTION
## Summary

Fixes a bug where entering a date in an invalid format (e.g. `4/3/07`) on the Client Search screen bypassed front-end validation and caused a system error from the backend.
Bug was already fixed in main after a rebase, so kept test and error message enhancements

## Changes

- **`ClientSearchCriteriaValidator`**: Updated to call the new overloaded method with `"d/M/yyyy"` as the date pattern, so that inputs like `4/3/07` are rejected with a clear validation message rather than reaching the backend.
- **`ClientSearchCriteriaValidatorTest`**: Updated tests to reflect the new validation behaviour.  Parameterized existing tests for neatness.  Wrapped errors.getFieldError()).getCode() in Objects.requireNonNull() in order to avoid potential (extremely unlikely) null pointer exception.

## Jira

[CCMSPUI-1074](https://dsdmoj.atlassian.net/browse/CCMSPUI-1074)

[CCMSPUI-1074]: https://dsdmoj.atlassian.net/browse/CCMSPUI-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ