### PR TITLE
feat(CCMSPUI-1034): Add Prior Authority Justification Character Validation

### DIFF
--- a/src/main/java/uk/gov/laa/ccms/caab/bean/validators/priorauthority/PriorAuthorityDetailsValidator.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/validators/priorauthority/PriorAuthorityDetailsValidator.java
@@ -1,6 +1,7 @@
 package uk.gov.laa.ccms.caab.bean.validators.priorauthority;
 
 import static uk.gov.laa.ccms.caab.constants.ValidationPatternConstants.CHARACTER_SET_E;
+import static uk.gov.laa.ccms.caab.constants.ValidationPatternConstants.CHARACTER_SET_G;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -60,7 +61,7 @@ public class PriorAuthorityDetailsValidator extends AbstractValidator {
       validateFieldFormat(
           "justification",
           priorAuthorityDetails.getJustification(),
-          CHARACTER_SET_E,
+          CHARACTER_SET_G,
           "Justification",
           errors);
     }
@@ -123,6 +124,12 @@ public class PriorAuthorityDetailsValidator extends AbstractValidator {
                   errors);
             }
             case FIELD_TYPE_FTS -> {
+              validateFieldFormat(
+                  "dynamicOptions[%s].fieldValue".formatted(key),
+                  value.getFieldValue(),
+                  CHARACTER_SET_E,
+                  value.getFieldDescription(),
+                  errors);
               validateFieldMaxLength(
                   "dynamicOptions[%s].fieldValue".formatted(key),
                   value.getFieldValue(),
@@ -130,13 +137,20 @@ public class PriorAuthorityDetailsValidator extends AbstractValidator {
                   value.getFieldDescription(),
                   errors);
             }
-            case FIELD_TYPE_FTL ->
-                validateFieldMaxLength(
-                    "dynamicOptions[%s].fieldValue".formatted(key),
-                    value.getFieldValue(),
-                    80,
-                    value.getFieldDescription(),
-                    errors);
+            case FIELD_TYPE_FTL -> {
+              validateFieldFormat(
+                  "dynamicOptions[%s].fieldValue".formatted(key),
+                  value.getFieldValue(),
+                  CHARACTER_SET_E,
+                  value.getFieldDescription(),
+                  errors);
+              validateFieldMaxLength(
+                  "dynamicOptions[%s].fieldValue".formatted(key),
+                  value.getFieldValue(),
+                  80,
+                  value.getFieldDescription(),
+                  errors);
+            }
             default -> {
               break;
             }

--- a/src/main/java/uk/gov/laa/ccms/caab/bean/validators/priorauthority/PriorAuthorityDetailsValidator.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/validators/priorauthority/PriorAuthorityDetailsValidator.java
@@ -1,5 +1,7 @@
 package uk.gov.laa.ccms.caab.bean.validators.priorauthority;
 
+import static uk.gov.laa.ccms.caab.constants.ValidationPatternConstants.CHARACTER_SET_E;
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -54,6 +56,14 @@ public class PriorAuthorityDetailsValidator extends AbstractValidator {
 
     validateRequiredField(
         "justification", priorAuthorityDetails.getJustification(), "Justification", errors);
+    if (StringUtils.hasText(priorAuthorityDetails.getJustification())) {
+      validateFieldFormat(
+          "justification",
+          priorAuthorityDetails.getJustification(),
+          CHARACTER_SET_E,
+          "Justification",
+          errors);
+    }
 
     if (priorAuthorityDetails.isValueRequired()) {
       validateRequiredField(

--- a/src/main/java/uk/gov/laa/ccms/caab/bean/validators/priorauthority/PriorAuthorityDetailsValidator.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/validators/priorauthority/PriorAuthorityDetailsValidator.java
@@ -1,7 +1,7 @@
 package uk.gov.laa.ccms.caab.bean.validators.priorauthority;
 
 import static uk.gov.laa.ccms.caab.constants.ValidationPatternConstants.CHARACTER_SET_E;
-import static uk.gov.laa.ccms.caab.constants.ValidationPatternConstants.CHARACTER_SET_G;
+import static uk.gov.laa.ccms.caab.constants.ValidationPatternConstants.STANDARD_CHARACTER_SET;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -54,6 +54,10 @@ public class PriorAuthorityDetailsValidator extends AbstractValidator {
         (PriorAuthorityDetailsFormData) target;
 
     validateRequiredField("summary", priorAuthorityDetails.getSummary(), "Summary", errors);
+    if (StringUtils.hasText(priorAuthorityDetails.getSummary())) {
+      validateFieldFormat(
+          "summary", priorAuthorityDetails.getSummary(), STANDARD_CHARACTER_SET, "Summary", errors);
+    }
 
     validateRequiredField(
         "justification", priorAuthorityDetails.getJustification(), "Justification", errors);
@@ -61,7 +65,7 @@ public class PriorAuthorityDetailsValidator extends AbstractValidator {
       validateFieldFormat(
           "justification",
           priorAuthorityDetails.getJustification(),
-          CHARACTER_SET_G,
+          STANDARD_CHARACTER_SET,
           "Justification",
           errors);
     }

--- a/src/main/java/uk/gov/laa/ccms/caab/constants/ValidationPatternConstants.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/constants/ValidationPatternConstants.java
@@ -111,11 +111,4 @@ public class ValidationPatternConstants {
    */
   public static final String CHARACTER_SET_F =
       "^[A-Za-z0-9\\&\\'\\(\\)\\.\\*\\-/!#$%,;\\?\\@\\[\\]_+\\=\\>£:&#92;&#96;\\\\]*$";
-
-  /**
-   * pattern to match what is known in provider-ui as 'characterSetG'. Valid characters are A-Z a-z
-   * 0-9 space ( ) . * - \ / ! # $ % , ; ? @ [ ] _ + = £ : \r \n
-   */
-  public static final String CHARACTER_SET_G =
-      "^[A-Za-z0-9 \\(\\)\\.\\*\\-\\\\/!#$%,;?@\\[\\]_+=£:\\r\\n]*$";
 }

--- a/src/main/java/uk/gov/laa/ccms/caab/constants/ValidationPatternConstants.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/constants/ValidationPatternConstants.java
@@ -111,4 +111,11 @@ public class ValidationPatternConstants {
    */
   public static final String CHARACTER_SET_F =
       "^[A-Za-z0-9\\&\\'\\(\\)\\.\\*\\-/!#$%,;\\?\\@\\[\\]_+\\=\\>£:&#92;&#96;\\\\]*$";
+
+  /**
+   * pattern to match what is known in provider-ui as 'characterSetG'. Valid characters are A-Z a-z
+   * 0-9 space ( ) . * - \ / ! # $ % , ; ? @ [ ] _ + = £ : \r \n
+   */
+  public static final String CHARACTER_SET_G =
+      "^[A-Za-z0-9 \\(\\)\\.\\*\\-\\\\/!#$%,;?@\\[\\]_+=£:\\r\\n]*$";
 }

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/validators/priorauthority/PriorAuthorityDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/validators/priorauthority/PriorAuthorityDetailsValidatorTest.java
@@ -119,4 +119,17 @@ class PriorAuthorityDetailsValidatorTest {
     assertTrue(errors.hasFieldErrors("justification"));
     assertFalse(errors.hasFieldErrors("summary"));
   }
+
+  @Test
+  public void
+      validate_whenJustificationInvalidCharactersButSummaryPresent_HasJustificationErrorOnly() {
+    priorAuthorityDetailsFormData.setSummary("Some summary");
+    priorAuthorityDetailsFormData.setJustification("Invalid characters &<#>");
+    priorAuthorityDetailsFormData.setValueRequired(false);
+
+    priorAuthorityDetailsValidator.validate(priorAuthorityDetailsFormData, errors);
+
+    assertTrue(errors.hasFieldErrors("justification"));
+    assertFalse(errors.hasFieldErrors("summary"));
+  }
 }

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/validators/priorauthority/PriorAuthorityDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/validators/priorauthority/PriorAuthorityDetailsValidatorTest.java
@@ -132,6 +132,18 @@ class PriorAuthorityDetailsValidatorTest {
   }
 
   @Test
+  public void validate_whenSummaryInvalidCharactersButJustificationPresent_HasSummaryErrorOnly() {
+    priorAuthorityDetailsFormData.setSummary("Invalid characters <@>");
+    priorAuthorityDetailsFormData.setJustification("Some justification");
+    priorAuthorityDetailsFormData.setValueRequired(false);
+
+    priorAuthorityDetailsValidator.validate(priorAuthorityDetailsFormData, errors);
+
+    assertTrue(errors.hasFieldErrors("summary"));
+    assertFalse(errors.hasFieldErrors("justification"));
+  }
+
+  @Test
   public void validate_whenJustificationMissingButSummaryPresent_HasJustificationErrorOnly() {
     priorAuthorityDetailsFormData.setSummary("Some summary");
     priorAuthorityDetailsFormData.setJustification(null);
@@ -147,7 +159,7 @@ class PriorAuthorityDetailsValidatorTest {
   public void
       validate_whenJustificationInvalidCharactersButSummaryPresent_HasJustificationErrorOnly() {
     priorAuthorityDetailsFormData.setSummary("Some summary");
-    priorAuthorityDetailsFormData.setJustification("Invalid characters \n &<#>");
+    priorAuthorityDetailsFormData.setJustification("Invalid characters <@>");
     priorAuthorityDetailsFormData.setValueRequired(false);
 
     priorAuthorityDetailsValidator.validate(priorAuthorityDetailsFormData, errors);

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/validators/priorauthority/PriorAuthorityDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/validators/priorauthority/PriorAuthorityDetailsValidatorTest.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.validation.BeanPropertyBindingResult;
@@ -108,6 +110,27 @@ class PriorAuthorityDetailsValidatorTest {
     assertTrue(errors.hasFieldErrors("dynamicOptions[intKey].fieldValue"));
   }
 
+  @ParameterizedTest
+  @CsvSource({"FTS,ftsKey", "FTL,ftlKey"})
+  public void validate_DynamicOptionsValidation_TextInvalidCharacters_HasErrors(
+      final String fieldType, final String key) {
+    priorAuthorityDetailsFormData.setSummary("Valid summary");
+    priorAuthorityDetailsFormData.setJustification("Valid justification");
+
+    final Map<String, DynamicOptionFormData> dynamicOptions = new HashMap<>();
+    final DynamicOptionFormData option = new DynamicOptionFormData();
+    option.setMandatory(true);
+    option.setFieldType(fieldType);
+    option.setFieldDescription("Short text option");
+    option.setFieldValue("Invalid characters &<#>");
+    dynamicOptions.put(key, option);
+    priorAuthorityDetailsFormData.setDynamicOptions(dynamicOptions);
+
+    priorAuthorityDetailsValidator.validate(priorAuthorityDetailsFormData, errors);
+
+    assertTrue(errors.hasFieldErrors("dynamicOptions[%s].fieldValue".formatted(key)));
+  }
+
   @Test
   public void validate_whenJustificationMissingButSummaryPresent_HasJustificationErrorOnly() {
     priorAuthorityDetailsFormData.setSummary("Some summary");
@@ -124,7 +147,7 @@ class PriorAuthorityDetailsValidatorTest {
   public void
       validate_whenJustificationInvalidCharactersButSummaryPresent_HasJustificationErrorOnly() {
     priorAuthorityDetailsFormData.setSummary("Some summary");
-    priorAuthorityDetailsFormData.setJustification("Invalid characters &<#>");
+    priorAuthorityDetailsFormData.setJustification("Invalid characters \n &<#>");
     priorAuthorityDetailsFormData.setValueRequired(false);
 
     priorAuthorityDetailsValidator.validate(priorAuthorityDetailsFormData, errors);


### PR DESCRIPTION
This pull request strengthens validation for the `PriorAuthorityDetailsValidator` by adding checks to ensure that the `summary`, `justification`, and certain dynamic option fields only contain allowed characters. Corresponding unit tests have also been added to verify these new validations and to ensure that errors are reported only for the relevant fields.

### Validation improvements

* Added character set validation for the `summary` and `justification` fields, ensuring only allowed characters are accepted (`STANDARD_CHARACTER_SET`).
* Enhanced validation for dynamic option fields of types `FTS` and `FTL` to enforce allowed character sets (`CHARACTER_SET_E`).
* Imported the necessary validation pattern constants for character set enforcement.

### Unit test enhancements

* Added parameterized and targeted tests to confirm that invalid characters in `summary`, `justification`, and dynamic option fields correctly trigger validation errors, and that only the relevant fields report errors.