### PR TITLE
fix(CCMSPUI-1030): Replace filename validation with sanitisation

### DIFF
--- a/.factorypath
+++ b/.factorypath
@@ -1,4 +1,0 @@
-<factorypath>
-    <factorypathentry kind="EXTJAR" id="/Users/alexander.walls/.gradle/caches/modules-2/files-2.1/org.mapstruct/mapstruct-processor/1.6.3/52e345c907fbf173b376586c7f8b131d53fa5867/mapstruct-processor-1.6.3.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="EXTJAR" id="/Users/alexander.walls/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.46/a5cfe99fdf320e84955ef653f2ce1bf789d11385/lombok-1.18.46.jar" enabled="true" runInBatchMode="false"/>
-</factorypath>

--- a/.factorypath
+++ b/.factorypath
@@ -1,0 +1,4 @@
+<factorypath>
+    <factorypathentry kind="EXTJAR" id="/Users/alexander.walls/.gradle/caches/modules-2/files-2.1/org.mapstruct/mapstruct-processor/1.6.3/52e345c907fbf173b376586c7f8b131d53fa5867/mapstruct-processor-1.6.3.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="EXTJAR" id="/Users/alexander.walls/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.46/a5cfe99fdf320e84955ef653f2ce1bf789d11385/lombok-1.18.46.jar" enabled="true" runInBatchMode="false"/>
+</factorypath>

--- a/src/main/java/uk/gov/laa/ccms/caab/bean/file/FileUploadFormData.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/file/FileUploadFormData.java
@@ -12,6 +12,9 @@ public abstract class FileUploadFormData {
   /** The multipart file data to upload. */
   private MultipartFile file;
 
+  /** The sanitised filename used for downstream processing. */
+  private String sanitisedFileName;
+
   /** The file extension. */
   private String fileExtension;
 

--- a/src/main/java/uk/gov/laa/ccms/caab/bean/validators/file/FileUploadValidator.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/bean/validators/file/FileUploadValidator.java
@@ -2,6 +2,7 @@ package uk.gov.laa.ccms.caab.bean.validators.file;
 
 import static uk.gov.laa.ccms.caab.util.DisplayUtil.getCommaDelimitedString;
 import static uk.gov.laa.ccms.caab.util.FileUtil.getFileExtension;
+import static uk.gov.laa.ccms.caab.util.FileUtil.sanitiseFileName;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -9,7 +10,6 @@ import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.tika.Tika;
-import org.springframework.util.StringUtils;
 import org.springframework.util.unit.DataSize;
 import org.springframework.validation.Errors;
 import uk.gov.laa.ccms.caab.bean.file.FileUploadFormData;
@@ -25,8 +25,6 @@ public abstract class FileUploadValidator extends AbstractValidator {
   protected static final String FILE_REQUIRED_ERROR = "Please select a file to upload";
 
   protected static final String FILE_REQUIRED_ERROR_CODE = "validation.error.selectAFile";
-
-  protected static final String INVALID_FILE_NAME_ERROR_CODE = "validation.error.invalidFileName";
 
   /** The error message for an invalid file extension. */
   protected static final String INVALID_EXTENSION_ERROR =
@@ -46,11 +44,20 @@ public abstract class FileUploadValidator extends AbstractValidator {
   protected static final String MULTIPLE_EXTENSION_ERROR_CODE =
       "validation.error.multipleExtension";
 
+  /** The error message for a filename that exceeds the maximum length. */
+  protected static final String FILENAME_LENGTH_ERROR =
+      "Filename is too long. The filename must be no more than 255 characters";
+
+  protected static final String FILENAME_LENGTH_ERROR_CODE = "validation.error.filenameTooLong";
+
   /** The error message for an invalid file extension. */
   public static final String MAX_FILESIZE_ERROR =
       "File is too large. The file must be less than %s";
 
   protected static final String MAX_FILESIZE_ERROR_CODE = "validation.error.maxFileSize";
+
+  /** The maximum length of a filename. */
+  protected static final Integer FILENAME_MAX_LENGTH = 255;
 
   /** The maximum length of the document description text area. */
   protected static final Integer DOCUMENT_DESCRIPTION_MAX_LENGTH = 255;
@@ -77,10 +84,19 @@ public abstract class FileUploadValidator extends AbstractValidator {
     if (fileUploadFormData.getFile() == null || fileUploadFormData.getFile().isEmpty()) {
       errors.rejectValue("file", FILE_REQUIRED_ERROR_CODE, FILE_REQUIRED_ERROR);
     } else {
-      fileUploadFormData.setFileExtension(getFileExtension(fileUploadFormData.getFile()));
+      final String sanitisedFilename =
+          sanitiseFileName(fileUploadFormData.getFile().getOriginalFilename());
+      if (sanitisedFilename.isBlank()) {
+        errors.rejectValue("file", FILE_REQUIRED_ERROR_CODE, FILE_REQUIRED_ERROR);
+        return;
+      }
 
-      if (!hasValidFileName(fileUploadFormData)) {
-        errors.rejectValue("file", INVALID_FILE_NAME_ERROR_CODE);
+      fileUploadFormData.setSanitisedFileName(sanitisedFilename);
+      fileUploadFormData.setFileExtension(getFileExtension(sanitisedFilename));
+
+      if (sanitisedFilename.length() > FILENAME_MAX_LENGTH) {
+        errors.rejectValue("file", FILENAME_LENGTH_ERROR_CODE, FILENAME_LENGTH_ERROR);
+        return;
       }
 
       if (!hasSingleExtension(fileUploadFormData)) {
@@ -198,31 +214,12 @@ public abstract class FileUploadValidator extends AbstractValidator {
    * @return true if the file only has a single extension, false otherwise.
    */
   protected boolean hasSingleExtension(FileUploadFormData fileUploadFormData) {
-    String filename = StringUtils.cleanPath(fileUploadFormData.getFile().getOriginalFilename());
+    String filename = fileUploadFormData.getSanitisedFileName();
 
     int lastDot = filename.lastIndexOf('.');
     int firstDot = filename.indexOf('.');
 
     return (firstDot > 0) && (firstDot == lastDot) && lastDot < (filename.length() - 1);
-  }
-
-  /**
-   * Check whether a file has a valid filename using a regex expression.
-   *
-   * @param fileUploadFormData the file upload form data object.
-   * @return true if the filename is valid, false otherwise.
-   */
-  protected boolean hasValidFileName(FileUploadFormData fileUploadFormData) {
-    String filename = StringUtils.cleanPath(fileUploadFormData.getFile().getOriginalFilename());
-
-    if (filename == null || filename.isEmpty()) {
-      return false;
-    } else if (filename.indexOf('\0') > -1) {
-      return false;
-    } else if (filename.contains("%00")) {
-      return false;
-    }
-    return filename.matches("^[A-Za-z0-9_-]+\\.[A-Za-z0-9]+$");
   }
 
   /**

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/EvidenceSectionController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/EvidenceSectionController.java
@@ -184,7 +184,7 @@ public class EvidenceSectionController {
           evidenceUploadFormData.getProviderId(),
           evidenceUploadFormData.getDocumentSender(),
           evidenceUploadFormData.getCcmsModule(),
-          evidenceUploadFormData.getFile().getOriginalFilename(),
+          evidenceUploadFormData.getSanitisedFileName(),
           evidenceUploadFormData.getFile().getInputStream());
     } catch (AvVirusFoundException | AvScanException | IOException e) {
       bindingResult.rejectValue("file", "scan.failure", e.getMessage());

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/notifications/ActionsAndNotificationsController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/notifications/ActionsAndNotificationsController.java
@@ -615,7 +615,7 @@ public class ActionsAndNotificationsController {
             null,
             null,
             null,
-            attachmentUploadFormData.getFile().getOriginalFilename(),
+            attachmentUploadFormData.getSanitisedFileName(),
             attachmentUploadFormData.getFile().getInputStream());
       } catch (AvVirusFoundException | AvScanException | IOException e) {
         bindingResult.rejectValue("file", "scan.failure", e.getMessage());

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/requests/ProviderRequestsController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/requests/ProviderRequestsController.java
@@ -294,7 +294,7 @@ public class ProviderRequestsController {
               null,
               null,
               null,
-              providerRequestDetailsForm.getFile().getOriginalFilename(),
+              providerRequestDetailsForm.getSanitisedFileName(),
               providerRequestDetailsForm.getFile().getInputStream());
         } catch (final AvVirusFoundException | AvScanException | IOException e) {
           bindingResult.rejectValue("file", "scan.failure", e.getMessage());
@@ -419,7 +419,7 @@ public class ProviderRequestsController {
           evidenceUploadFormData.getProviderId(),
           evidenceUploadFormData.getDocumentSender(),
           evidenceUploadFormData.getCcmsModule(),
-          evidenceUploadFormData.getFile().getOriginalFilename(),
+          evidenceUploadFormData.getSanitisedFileName(),
           evidenceUploadFormData.getFile().getInputStream());
     } catch (AvVirusFoundException | AvScanException | IOException e) {
       bindingResult.rejectValue("file", "scan.failure", e.getMessage());

--- a/src/main/java/uk/gov/laa/ccms/caab/mapper/ProviderRequestsMapper.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/mapper/ProviderRequestsMapper.java
@@ -75,6 +75,7 @@ public interface ProviderRequestsMapper {
   @Mapping(target = "dynamicOptions", ignore = true)
   @Mapping(target = "additionalInformation", ignore = true)
   @Mapping(target = "file", ignore = true)
+  @Mapping(target = "sanitisedFileName", ignore = true)
   @Mapping(target = "fileExtension", ignore = true)
   @Mapping(target = "documentType", ignore = true)
   @Mapping(target = "documentTypeDisplayValue", ignore = true)

--- a/src/main/java/uk/gov/laa/ccms/caab/util/FileUtil.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/util/FileUtil.java
@@ -1,6 +1,7 @@
 package uk.gov.laa.ccms.caab.util;
 
 import java.util.Optional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.laa.ccms.caab.exception.CaabApplicationException;
 
@@ -42,6 +43,20 @@ public final class FileUtil {
    */
   public static String getFilename(String name, String extension) {
     return name + (extension == null || extension.equals(name) ? "" : "." + extension);
+  }
+
+  /**
+   * Sanitise a filename by replacing characters outside the allowed set with underscores.
+   *
+   * @param filename the original filename.
+   * @return the sanitised filename.
+   */
+  public static String sanitiseFileName(String filename) {
+    if (filename == null || filename.isBlank()) {
+      return "";
+    }
+
+    return StringUtils.cleanPath(filename).replaceAll("[^A-Za-z0-9_.-]", "_");
   }
 
   private FileUtil() {}

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/validators/evidence/EvidenceUploadValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/validators/evidence/EvidenceUploadValidatorTest.java
@@ -112,19 +112,6 @@ class EvidenceUploadValidatorTest {
   }
 
   @Test
-  public void validate_fileName() {
-    evidenceUploadFormData = buildEvidenceUploadFormData();
-    evidenceUploadFormData.setFile(
-        new MockMultipartFile(
-            "invalid name.pdf", "invalid name.pdf", "application/pdf", "the file data".getBytes()));
-
-    validator.validate(evidenceUploadFormData, errors);
-    assertEquals(1, errors.getErrorCount());
-    assertNotNull(errors.getFieldError("file"));
-    assertEquals("validation.error.invalidFileName", errors.getFieldError("file").getCode());
-  }
-
-  @Test
   @DisplayName("validate - Adds error for invalid magic bytes")
   void validate_InvalidMagicBytes_HasErrors() {
     evidenceUploadFormData = buildEvidenceUploadFormData();

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/validators/evidence/EvidenceUploadValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/validators/evidence/EvidenceUploadValidatorTest.java
@@ -55,6 +55,24 @@ class EvidenceUploadValidatorTest {
 
     validator.validate(evidenceUploadFormData, errors);
     assertFalse(errors.hasErrors());
+    assertEquals("originalName.pdf", evidenceUploadFormData.getSanitisedFileName());
+  }
+
+  @Test
+  void validate_sanitizesFilename() {
+    evidenceUploadFormData = buildEvidenceUploadFormData();
+    evidenceUploadFormData.setFile(
+        new MockMultipartFile(
+            "theFile",
+            "My interesting%filename!.pdf",
+            "application/pdf",
+            "the file data".getBytes()));
+
+    validator.validate(evidenceUploadFormData, errors);
+
+    assertFalse(errors.hasErrors());
+    assertEquals("My_interesting_filename_.pdf", evidenceUploadFormData.getSanitisedFileName());
+    assertEquals("pdf", evidenceUploadFormData.getFileExtension());
   }
 
   @Test
@@ -152,6 +170,50 @@ class EvidenceUploadValidatorTest {
     validator.validate(evidenceUploadFormData, errors);
     assertEquals(1, errors.getErrorCount());
     assertNotNull(errors.getFieldError("documentDescription"));
+  }
+
+  @Test
+  @DisplayName("validate - Rejects double extension")
+  void validate_DoubleExtension_HasErrors() {
+    evidenceUploadFormData = buildEvidenceUploadFormData();
+    evidenceUploadFormData.setFile(
+        new MockMultipartFile(
+            "file", "document.pdf.exe", "application/pdf", "the file data".getBytes()));
+
+    validator.validate(evidenceUploadFormData, errors);
+
+    assertTrue(errors.hasErrors());
+    assertNotNull(errors.getFieldError("file"));
+    assertEquals("validation.error.multipleExtension", errors.getFieldError("file").getCode());
+  }
+
+  @Test
+  @DisplayName("validate - Sanitises and accepts filename with null-byte escape")
+  void validate_NullByteEscapeInFilename_Sanitized() {
+    evidenceUploadFormData = buildEvidenceUploadFormData();
+    evidenceUploadFormData.setFile(
+        new MockMultipartFile(
+            "file", "malicious%00.pdf", "application/pdf", "the file data".getBytes()));
+
+    validator.validate(evidenceUploadFormData, errors);
+
+    assertFalse(errors.hasErrors());
+    assertEquals("malicious_00.pdf", evidenceUploadFormData.getSanitisedFileName());
+  }
+
+  @Test
+  @DisplayName("validate - Rejects filename exceeding 255 characters")
+  void validate_FilenameExceeds255Chars_HasErrors() {
+    evidenceUploadFormData = buildEvidenceUploadFormData();
+    final String longName = "a".repeat(252) + ".pdf";
+    evidenceUploadFormData.setFile(
+        new MockMultipartFile("file", longName, "application/pdf", "the file data".getBytes()));
+
+    validator.validate(evidenceUploadFormData, errors);
+
+    assertTrue(errors.hasErrors());
+    assertNotNull(errors.getFieldError("file"));
+    assertEquals("validation.error.filenameTooLong", errors.getFieldError("file").getCode());
   }
 
   private EvidenceUploadFormData buildEvidenceUploadFormData() {

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/validators/notification/NotificationAttachmentUploadValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/validators/notification/NotificationAttachmentUploadValidatorTest.java
@@ -58,6 +58,27 @@ public class NotificationAttachmentUploadValidatorTest {
 
     validator.validate(notificationAttachmentUploadFormData, errors);
     assertFalse(errors.hasErrors());
+    assertEquals("originalName.pdf", notificationAttachmentUploadFormData.getSanitisedFileName());
+  }
+
+  @Test
+  public void validate_electronic_sanitizesFilename() {
+    notificationAttachmentUploadFormData = buildNotificationAttachmentUploadFormData();
+    notificationAttachmentUploadFormData.setSendBy(SendBy.ELECTRONIC);
+    notificationAttachmentUploadFormData.setFile(
+        new MockMultipartFile(
+            "theFile",
+            "My interesting%filename!.pdf",
+            "application/pdf",
+            "the file data".getBytes()));
+
+    validator.validate(notificationAttachmentUploadFormData, errors);
+
+    assertFalse(errors.hasErrors());
+    assertEquals(
+        "My_interesting_filename_.pdf",
+        notificationAttachmentUploadFormData.getSanitisedFileName());
+    assertEquals("pdf", notificationAttachmentUploadFormData.getFileExtension());
   }
 
   @Test

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/validators/notification/NotificationAttachmentUploadValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/validators/notification/NotificationAttachmentUploadValidatorTest.java
@@ -122,19 +122,6 @@ public class NotificationAttachmentUploadValidatorTest {
   }
 
   @Test
-  public void validate_fileName() {
-    notificationAttachmentUploadFormData = buildNotificationAttachmentUploadFormData();
-    notificationAttachmentUploadFormData.setFile(
-        new MockMultipartFile(
-            "invalid name.pdf", "invalid name.pdf", "application/pdf", "the file data".getBytes()));
-
-    validator.validate(notificationAttachmentUploadFormData, errors);
-    assertEquals(1, errors.getErrorCount());
-    assertNotNull(errors.getFieldError("file"));
-    assertEquals("validation.error.invalidFileName", errors.getFieldError("file").getCode());
-  }
-
-  @Test
   @DisplayName("validate - Adds error for invalid magic bytes")
   void validate_InvalidMagicBytes_HasErrors() {
     notificationAttachmentUploadFormData = buildNotificationAttachmentUploadFormData();

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/validators/request/ProviderRequestDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/validators/request/ProviderRequestDetailsValidatorTest.java
@@ -80,6 +80,24 @@ class ProviderRequestDetailsValidatorTest {
     providerRequestDetailsValidator.validate(formData, errors);
 
     assertFalse(errors.hasErrors());
+    assertEquals("valid.pdf", formData.getSanitisedFileName());
+  }
+
+  @Test
+  @DisplayName("validate - Sanitizes filename when claim upload is enabled")
+  void validate_SanitizedFilename_NoErrors() {
+    final MockMultipartFile file =
+        new MockMultipartFile(
+            "file", "My interesting%filename!.pdf", "application/pdf", "something".getBytes());
+    formData.setFile(file);
+    formData.setClaimUploadEnabled(true);
+    formData.setAdditionalInformation("");
+
+    providerRequestDetailsValidator.validate(formData, errors);
+
+    assertFalse(errors.hasErrors());
+    assertEquals("My_interesting_filename_.pdf", formData.getSanitisedFileName());
+    assertEquals("pdf", formData.getFileExtension());
   }
 
   @Test

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/validators/request/ProviderRequestDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/validators/request/ProviderRequestDetailsValidatorTest.java
@@ -226,24 +226,6 @@ class ProviderRequestDetailsValidatorTest {
   }
 
   @Test
-  @DisplayName("validate - Adds error for invalid filename")
-  void validate_InvalidFilename_HasErrors() {
-    final MockMultipartFile invalidFile =
-        new MockMultipartFile(
-            "invalid name.pdf", "invalid name.pdf", "application/pdf", new byte[3]);
-    formData.setFile(invalidFile);
-    formData.setFileExtension("pdf");
-    formData.setClaimUploadEnabled(true);
-    formData.setAdditionalInformation("");
-
-    providerRequestDetailsValidator.validate(formData, errors);
-
-    assertTrue(errors.hasErrors());
-    assertNotNull(errors.getFieldError("file"));
-    assertEquals("validation.error.invalidFileName", errors.getFieldError("file").getCode());
-  }
-
-  @Test
   @DisplayName("validate - Adds error for invalid magic bytes")
   void validate_InvalidMagicBytes_HasErrors() {
     final MockMultipartFile invalidFile =

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/validators/request/ProviderRequestDocumentUploadValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/validators/request/ProviderRequestDocumentUploadValidatorTest.java
@@ -76,21 +76,6 @@ class ProviderRequestDocumentUploadValidatorTest {
   }
 
   @Test
-  @DisplayName("validate - Adds error when filename is invalid")
-  public void validate_InvalidFilename_HasErrors() {
-    final MockMultipartFile invalidNamedFile =
-        new MockMultipartFile(
-            "invalid name.pdf", "invalid name.pdf", "application/pdf", "the file data".getBytes());
-    evidenceUploadFormData.setFile(invalidNamedFile);
-
-    providerRequestDocumentUploadValidator.validate(evidenceUploadFormData, errors);
-
-    assertTrue(errors.hasErrors());
-    assertNotNull(errors.getFieldError("file"));
-    assertEquals("validation.error.invalidFileName", errors.getFieldError("file").getCode());
-  }
-
-  @Test
   @DisplayName("validate - Adds error for invalid magic bytes")
   void validate_InvalidMagicBytes_HasErrors() {
     final MockMultipartFile invalidFile =

--- a/src/test/java/uk/gov/laa/ccms/caab/bean/validators/request/ProviderRequestDocumentUploadValidatorTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/bean/validators/request/ProviderRequestDocumentUploadValidatorTest.java
@@ -76,6 +76,23 @@ class ProviderRequestDocumentUploadValidatorTest {
   }
 
   @Test
+  @DisplayName("validate - Sanitizes filename instead of rejecting it")
+  public void validate_SanitizedFilename_NoErrors() {
+    final MockMultipartFile file =
+        new MockMultipartFile(
+            "file", "My interesting%filename!.pdf", "application/pdf", "the file data".getBytes());
+    evidenceUploadFormData.setFile(file);
+    evidenceUploadFormData.setDocumentType("docType");
+
+    providerRequestDocumentUploadValidator.validate(evidenceUploadFormData, errors);
+
+    assertNotNull(errors.getFieldError("file"));
+    assertEquals("validation.error.invalidMagicBytes", errors.getFieldError("file").getCode());
+    assertEquals("My_interesting_filename_.pdf", evidenceUploadFormData.getSanitisedFileName());
+    assertEquals("pdf", evidenceUploadFormData.getFileExtension());
+  }
+
+  @Test
   @DisplayName("validate - Adds error for invalid magic bytes")
   void validate_InvalidMagicBytes_HasErrors() {
     final MockMultipartFile invalidFile =

--- a/src/test/java/uk/gov/laa/ccms/caab/controller/application/section/EvidenceSectionControllerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/controller/application/section/EvidenceSectionControllerTest.java
@@ -214,7 +214,7 @@ class EvidenceSectionControllerTest {
             eq(formData.getProviderId()),
             eq(formData.getDocumentSender()),
             eq(APPLICATION),
-            eq(formData.getFile().getOriginalFilename()),
+            eq(formData.getSanitisedFileName()),
             any(InputStream.class));
 
     List<EvidenceRequired> evidenceRequired = List.of(new EvidenceRequired("code", "desc"));
@@ -429,6 +429,7 @@ class EvidenceSectionControllerTest {
             "theFile", "originalName.pdf", "contentType", "the file data".getBytes()));
     formData.setProviderId(789);
     formData.setRegisteredDocumentId("regId");
+    formData.setSanitisedFileName(formData.getFile().getOriginalFilename());
     return formData;
   }
 }

--- a/src/test/java/uk/gov/laa/ccms/caab/controller/notifications/ActionsAndNotificationsControllerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/controller/notifications/ActionsAndNotificationsControllerTest.java
@@ -864,6 +864,7 @@ class ActionsAndNotificationsControllerTest {
           new NotificationAttachmentUploadFormData();
       attachmentUploadFormData.setSendBy(SendBy.ELECTRONIC);
       attachmentUploadFormData.setFile(file);
+      attachmentUploadFormData.setSanitisedFileName(filename);
 
       NotificationAttachmentDetail notificationAttachment = new NotificationAttachmentDetail();
       notificationAttachment.setSendBy("E");
@@ -894,8 +895,7 @@ class ActionsAndNotificationsControllerTest {
           .hasStatus3xxRedirection()
           .hasRedirectedUrl("/notifications/234/provide-documents-or-evidence");
 
-      verify(avScanService)
-          .performAvScan(any(), any(), any(), any(), eq(file.getOriginalFilename()), any());
+      verify(avScanService).performAvScan(any(), any(), any(), any(), eq(filename), any());
       verify(notificationService)
           .addDraftNotificationAttachment(notificationAttachment, userDetails.getLoginId());
     }

--- a/src/test/java/uk/gov/laa/ccms/caab/util/FileUtilTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/util/FileUtilTest.java
@@ -38,15 +38,22 @@ class FileUtilTest {
 
   @Test
   void testSanitizeFileName_replacesDisallowedCharactersWithUnderscore() {
-    final String result = FileUtil.sanitizeFileName("My interesting%filename!.pdf");
+    final String result = FileUtil.sanitiseFileName("My interesting%filename!.pdf");
 
     assertEquals("My_interesting_filename_.pdf", result);
   }
 
   @Test
   void testSanitizeFileName_keepsAllowedCharacters() {
-    final String result = FileUtil.sanitizeFileName("Valid_File-Name123.pdf");
+    final String result = FileUtil.sanitiseFileName("Valid_File-Name123.pdf");
 
     assertEquals("Valid_File-Name123.pdf", result);
+  }
+
+  @Test
+  void testSanitiseFileName_blankFilename_returnsBlank() {
+    final String result = FileUtil.sanitiseFileName("   ");
+
+    assertEquals("", result);
   }
 }

--- a/src/test/java/uk/gov/laa/ccms/caab/util/FileUtilTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/util/FileUtilTest.java
@@ -35,4 +35,18 @@ class FileUtilTest {
     assertNotNull(result);
     assertEquals(filename, result);
   }
+
+  @Test
+  void testSanitizeFileName_replacesDisallowedCharactersWithUnderscore() {
+    final String result = FileUtil.sanitizeFileName("My interesting%filename!.pdf");
+
+    assertEquals("My_interesting_filename_.pdf", result);
+  }
+
+  @Test
+  void testSanitizeFileName_keepsAllowedCharacters() {
+    final String result = FileUtil.sanitizeFileName("Valid_File-Name123.pdf");
+
+    assertEquals("Valid_File-Name123.pdf", result);
+  }
 }


### PR DESCRIPTION
## Summary
- replace filename character rejection with filename sanitisation for upload flows
- store the sanitised filename on upload form data and use it for downstream AV scan calls
- extend upload validation coverage for sanitisation, multiple extensions, null-byte-like input, and 255-character filename limits

## Details
This unwinds the strict filename validation introduced previously and aligns upload behaviour with CCMSPUI-1030.

Uploads now accept filenames containing spaces and other previously rejected characters by normalising unsupported characters to underscores before validation and downstream processing.

The shared upload validator now also enforces:
- a single file extension
- a maximum filename length of 255 characters
- existing extension/content validation rules

## Testing
- targeted upload validator tests
- targeted controller tests for evidence and notifications upload flows
