### PR TITLE
feat(CCMSPUI-1081): Update Validation to set isDateOfBirthMandatory on editing opponents and application submission

### DIFF
--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/ApplicationSubmissionController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/ApplicationSubmissionController.java
@@ -546,22 +546,16 @@ public class ApplicationSubmissionController {
       final IndividualOpponentFormData individualOpponent,
       final List<RelationshipToCaseLookupValueDetail> personToCaseRelationships) {
     final String relationshipToCaseCode = individualOpponent.getRelationshipToCase();
-    if (relationshipToCaseCode == null) {
+    if (relationshipToCaseCode == null || relationshipToCaseCode.isBlank()) {
       return false;
     }
 
-    final RelationshipToCaseLookupValueDetail relationshipToCase =
-        personToCaseRelationships.stream()
-            .filter(relationship -> relationshipToCaseCode.equals(relationship.getCode()))
-            .findFirst()
-            .orElseThrow(
-                () ->
-                    new CaabApplicationException(
-                        "Failed to find matching relationship to case with code: %s"
-                            .formatted(individualOpponent.getRelationshipToCase())));
-
-    return Boolean.TRUE.equals(relationshipToCase.getDateOfBirthMandatory());
-  }
+    return personToCaseRelationships.stream()
+        .filter(relationship -> relationshipToCaseCode.equals(relationship.getCode()))
+        .findFirst()
+        .map(relationship -> Boolean.TRUE.equals(relationship.getDateOfBirthMandatory()))
+        .orElse(false);
+  
 
   /**
    * Retrieves a list of error messages from the model by attribute name.

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/ApplicationSubmissionController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/ApplicationSubmissionController.java
@@ -100,6 +100,8 @@ import uk.gov.laa.ccms.data.model.AssessmentSummaryEntityLookupDetail;
 import uk.gov.laa.ccms.data.model.AssessmentSummaryEntityLookupValueDetail;
 import uk.gov.laa.ccms.data.model.CommonLookupValueDetail;
 import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
+import uk.gov.laa.ccms.data.model.RelationshipToCaseLookupDetail;
+import uk.gov.laa.ccms.data.model.RelationshipToCaseLookupValueDetail;
 import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.soa.gateway.model.CaseTransactionResponse;
 import uk.gov.laa.ccms.soa.gateway.model.ClientDetail;
@@ -508,8 +510,19 @@ public class ApplicationSubmissionController {
     }
 
     final Set<String> opponentErrors = new HashSet<>();
+    final List<RelationshipToCaseLookupValueDetail> personToCaseRelationships =
+        opponents.stream().anyMatch(IndividualOpponentFormData.class::isInstance)
+            ? lookupService
+                .getPersonToCaseRelationships()
+                .map(RelationshipToCaseLookupDetail::getContent)
+                .blockOptional()
+                .orElseThrow(() -> new CaabApplicationException("Failed to retrieve lookup data"))
+            : List.of();
+
     for (final AbstractOpponentFormData opponent : opponents) {
-      if (opponent instanceof IndividualOpponentFormData) {
+      if (opponent instanceof IndividualOpponentFormData individualOpponent) {
+        individualOpponent.setDateOfBirthMandatory(
+            isIndividualDateOfBirthMandatory(individualOpponent, personToCaseRelationships));
         if (validateAndAddErrors(
             opponent, individualOpponentValidator, model, "individualOpponent")) {
           opponentErrors.addAll(getErrorsFromModel(model, "individualOpponent"));
@@ -527,6 +540,27 @@ public class ApplicationSubmissionController {
       return true;
     }
     return false;
+  }
+
+  private boolean isIndividualDateOfBirthMandatory(
+      final IndividualOpponentFormData individualOpponent,
+      final List<RelationshipToCaseLookupValueDetail> personToCaseRelationships) {
+    final String relationshipToCaseCode = individualOpponent.getRelationshipToCase();
+    if (relationshipToCaseCode == null) {
+      return false;
+    }
+
+    final RelationshipToCaseLookupValueDetail relationshipToCase =
+        personToCaseRelationships.stream()
+            .filter(relationship -> relationshipToCaseCode.equals(relationship.getCode()))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new CaabApplicationException(
+                        "Failed to find matching relationship to case with code: %s"
+                            .formatted(individualOpponent.getRelationshipToCase())));
+
+    return Boolean.TRUE.equals(relationshipToCase.getDateOfBirthMandatory());
   }
 
   /**

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/ApplicationSubmissionController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/ApplicationSubmissionController.java
@@ -554,8 +554,12 @@ public class ApplicationSubmissionController {
         .filter(relationship -> relationshipToCaseCode.equals(relationship.getCode()))
         .findFirst()
         .map(relationship -> Boolean.TRUE.equals(relationship.getDateOfBirthMandatory()))
-        .orElse(false);
-  
+        .orElseThrow(
+            () ->
+                new CaabApplicationException(
+                    "Failed to find matching relationship to case with code: %s"
+                        .formatted(individualOpponent.getRelationshipToCase())));
+  }
 
   /**
    * Retrieves a list of error messages from the model by attribute name.

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionController.java
@@ -407,30 +407,7 @@ public class OpponentsSectionController {
       final Model model) {
 
     CaseContext resolvedCaseContext = resolveCaseContext(caseContext, request);
-    // If the user has selected a relationship to case, we need to lookup this
-    // record again to determine if date of birth is mandatory.
-    if (StringUtils.hasText(opponentFormData.getRelationshipToCase())) {
-      RelationshipToCaseLookupValueDetail relationshipToCase =
-          lookupService
-              .getPersonToCaseRelationship(opponentFormData.getRelationshipToCase())
-              .map(
-                  relationshipToCaseLookupValueDetail ->
-                      relationshipToCaseLookupValueDetail.orElse(
-                          new RelationshipToCaseLookupValueDetail()
-                              .code(opponentFormData.getRelationshipToCase())
-                              .description(opponentFormData.getRelationshipToCase())))
-              .blockOptional()
-              .orElseThrow(
-                  () ->
-                      new CaabApplicationException(
-                          "Failed to retrieve relationship to case with code: %s"
-                              .formatted(opponentFormData.getRelationshipToCase())));
-
-      opponentFormData.setDateOfBirthMandatory(relationshipToCase.getDateOfBirthMandatory());
-    }
-
-    opponentFormData.setDateOfBirth(
-        DateUtils.normaliseComponentDateIfValid(opponentFormData.getDateOfBirth()));
+    prepareIndividualOpponentForValidation(opponentFormData);
     individualOpponentValidator.validate(opponentFormData, bindingResult);
 
     if (bindingResult.hasErrors()) {
@@ -529,8 +506,7 @@ public class OpponentsSectionController {
     } else {
       // Validate individual opponent.
       if (currentOpponent instanceof IndividualOpponentFormData individualOpponent) {
-        individualOpponent.setDateOfBirth(
-            DateUtils.normaliseComponentDateIfValid(individualOpponent.getDateOfBirth()));
+        prepareIndividualOpponentForValidation(individualOpponent);
       }
       individualOpponentValidator.validate(currentOpponent, bindingResult);
 
@@ -701,6 +677,35 @@ public class OpponentsSectionController {
     return resolveCaseContext(caseContext).isAmendment()
         ? Boolean.TRUE.equals(opponent.getEditable())
         : Boolean.TRUE.equals(opponent.getDeletable());
+  }
+
+  private void prepareIndividualOpponentForValidation(
+      final IndividualOpponentFormData individualOpponent) {
+    // If the user has selected a relationship to case, we need to lookup this
+    // record again to determine if date of birth is mandatory.
+    if (StringUtils.hasText(individualOpponent.getRelationshipToCase())) {
+      RelationshipToCaseLookupValueDetail relationshipToCase =
+          lookupService
+              .getPersonToCaseRelationship(individualOpponent.getRelationshipToCase())
+              .map(
+                  relationshipToCaseLookupValueDetail ->
+                      relationshipToCaseLookupValueDetail.orElse(
+                          new RelationshipToCaseLookupValueDetail()
+                              .code(individualOpponent.getRelationshipToCase())
+                              .description(individualOpponent.getRelationshipToCase())))
+              .blockOptional()
+              .orElseThrow(
+                  () ->
+                      new CaabApplicationException(
+                          "Failed to retrieve relationship to case with code: %s"
+                              .formatted(individualOpponent.getRelationshipToCase())));
+
+      individualOpponent.setDateOfBirthMandatory(
+          Boolean.TRUE.equals(relationshipToCase.getDateOfBirthMandatory()));
+    }
+
+    individualOpponent.setDateOfBirth(
+        DateUtils.normaliseComponentDateIfValid(individualOpponent.getDateOfBirth()));
   }
 
   private void populateOrganisationSearchDropdowns(final Model model) {

--- a/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionController.java
+++ b/src/main/java/uk/gov/laa/ccms/caab/controller/application/section/OpponentsSectionController.java
@@ -683,6 +683,7 @@ public class OpponentsSectionController {
       final IndividualOpponentFormData individualOpponent) {
     // If the user has selected a relationship to case, we need to lookup this
     // record again to determine if date of birth is mandatory.
+    individualOpponent.setDateOfBirthMandatory(false);
     if (StringUtils.hasText(individualOpponent.getRelationshipToCase())) {
       RelationshipToCaseLookupValueDetail relationshipToCase =
           lookupService

--- a/src/test/java/uk/gov/laa/ccms/caab/controller/application/section/ApplicationSubmissionControllerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/controller/application/section/ApplicationSubmissionControllerTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -112,6 +113,8 @@ import uk.gov.laa.ccms.caab.service.LookupService;
 import uk.gov.laa.ccms.data.model.AssessmentSummaryEntityLookupDetail;
 import uk.gov.laa.ccms.data.model.AssessmentSummaryEntityLookupValueDetail;
 import uk.gov.laa.ccms.data.model.DeclarationLookupDetail;
+import uk.gov.laa.ccms.data.model.RelationshipToCaseLookupDetail;
+import uk.gov.laa.ccms.data.model.RelationshipToCaseLookupValueDetail;
 import uk.gov.laa.ccms.data.model.UserDetail;
 import uk.gov.laa.ccms.soa.gateway.model.CaseTransactionResponse;
 
@@ -433,7 +436,17 @@ class ApplicationSubmissionControllerTest {
     mockApplicationDetail.setPriorAuthorities(List.of(mockPriorAuthorityDetail));
 
     final IndividualOpponentFormData mockIndividualOpponent = new IndividualOpponentFormData();
+    mockIndividualOpponent.setRelationshipToCase("OPP");
     final List<AbstractOpponentFormData> mockOpponents = List.of(mockIndividualOpponent);
+
+    final RelationshipToCaseLookupValueDetail relationship =
+        new RelationshipToCaseLookupValueDetail();
+    relationship.setCode("OPP");
+    relationship.setDateOfBirthMandatory(false);
+
+    final RelationshipToCaseLookupDetail mockPersonToCaseRelationships =
+        new RelationshipToCaseLookupDetail();
+    mockPersonToCaseRelationships.setContent(List.of(relationship));
 
     final ProceedingFlowFormData proceedingFlowFormData = new ProceedingFlowFormData("edit");
     proceedingFlowFormData.setMatterTypeDetails(new ProceedingFormDataMatterTypeDetails());
@@ -452,6 +465,8 @@ class ApplicationSubmissionControllerTest {
     when(applicationService.getApplication(applicationId))
         .thenReturn(Mono.just(mockApplicationDetail));
     when(applicationService.getOpponents(applicationId)).thenReturn(mockOpponents);
+    when(lookupService.getPersonToCaseRelationships())
+        .thenReturn(Mono.just(mockPersonToCaseRelationships));
     when(lookupService.getOrderTypeDescription(any()))
         .thenReturn(Mono.just("Order Type Description"));
 
@@ -1033,8 +1048,23 @@ class ApplicationSubmissionControllerTest {
 
   @Test
   @DisplayName("Test validateOpponents with IndividualOpponentFormData returns true with errors")
-  void testValidateOpponents_WithIndividualOpponentErrors() {
-    final List<AbstractOpponentFormData> opponents = List.of(new IndividualOpponentFormData());
+  void testValidateOpponents_WithIndividualOpponentErrors_DateOfBirthNotMandatory() {
+    final IndividualOpponentFormData opponent = new IndividualOpponentFormData();
+    opponent.setRelationshipToCase("OPP");
+    final List<AbstractOpponentFormData> opponents = List.of(opponent);
+
+    final RelationshipToCaseLookupValueDetail relationship =
+        new RelationshipToCaseLookupValueDetail();
+    relationship.setCode("OPP");
+    relationship.setDateOfBirthMandatory(false);
+    final RelationshipToCaseLookupDetail mockPersonToCaseRelationships =
+        new RelationshipToCaseLookupDetail();
+    mockPersonToCaseRelationships.setContent(List.of(relationship));
+    when(lookupService.getPersonToCaseRelationships())
+        .thenReturn(Mono.just(mockPersonToCaseRelationships));
+
+    final ArgumentCaptor<IndividualOpponentFormData> opponentCaptor =
+        ArgumentCaptor.forClass(IndividualOpponentFormData.class);
 
     doAnswer(
             invocation -> {
@@ -1044,7 +1074,7 @@ class ApplicationSubmissionControllerTest {
               return null;
             })
         .when(individualOpponentValidator)
-        .validate(any(), any());
+        .validate(opponentCaptor.capture(), any());
 
     when(model.containsAttribute("individualOpponent")).thenReturn(true);
     when(model.getAttribute("individualOpponent")).thenReturn(List.of("Error 1"));
@@ -1052,6 +1082,47 @@ class ApplicationSubmissionControllerTest {
     final boolean result = applicationSubmissionController.validateOpponents(opponents, model);
 
     assertTrue(result);
+    assertFalse(opponentCaptor.getValue().isDateOfBirthMandatory());
+  }
+
+  @Test
+  @DisplayName("Test validateOpponents with IndividualOpponentFormData returns true with errors")
+  void testValidateOpponents_WithIndividualOpponentErrors_DateOfBirthMandatory() {
+    final IndividualOpponentFormData opponent = new IndividualOpponentFormData();
+    opponent.setRelationshipToCase("CHILD");
+    final List<AbstractOpponentFormData> opponents = List.of(opponent);
+
+    final RelationshipToCaseLookupValueDetail relationship =
+        new RelationshipToCaseLookupValueDetail();
+    relationship.setCode("CHILD");
+    relationship.setDateOfBirthMandatory(true);
+
+    final RelationshipToCaseLookupDetail mockPersonToCaseRelationships =
+        new RelationshipToCaseLookupDetail();
+    mockPersonToCaseRelationships.setContent(List.of(relationship));
+    when(lookupService.getPersonToCaseRelationships())
+        .thenReturn(Mono.just(mockPersonToCaseRelationships));
+
+    final ArgumentCaptor<IndividualOpponentFormData> opponentCaptor =
+        ArgumentCaptor.forClass(IndividualOpponentFormData.class);
+
+    doAnswer(
+            invocation -> {
+              final Errors errors = invocation.getArgument(1);
+              errors.reject(
+                  "individualOpponent.required", "Error: Individual opponent validation failed.");
+              return null;
+            })
+        .when(individualOpponentValidator)
+        .validate(opponentCaptor.capture(), any());
+
+    when(model.containsAttribute("individualOpponent")).thenReturn(true);
+    when(model.getAttribute("individualOpponent")).thenReturn(List.of("Error 1"));
+
+    final boolean result = applicationSubmissionController.validateOpponents(opponents, model);
+
+    assertTrue(result);
+    assertTrue(opponentCaptor.getValue().isDateOfBirthMandatory());
   }
 
   @Test

--- a/src/test/java/uk/gov/laa/ccms/caab/controller/application/section/ApplicationSubmissionControllerTest.java
+++ b/src/test/java/uk/gov/laa/ccms/caab/controller/application/section/ApplicationSubmissionControllerTest.java
@@ -1047,7 +1047,8 @@ class ApplicationSubmissionControllerTest {
   }
 
   @Test
-  @DisplayName("Test validateOpponents with IndividualOpponentFormData returns true with errors")
+  @DisplayName(
+      "Test validateOpponents with IndividualOpponentFormData returns true with errors and date of birth not mandatory")
   void testValidateOpponents_WithIndividualOpponentErrors_DateOfBirthNotMandatory() {
     final IndividualOpponentFormData opponent = new IndividualOpponentFormData();
     opponent.setRelationshipToCase("OPP");
@@ -1086,7 +1087,8 @@ class ApplicationSubmissionControllerTest {
   }
 
   @Test
-  @DisplayName("Test validateOpponents with IndividualOpponentFormData returns true with errors")
+  @DisplayName(
+      "Test validateOpponents with IndividualOpponentFormData returns true with errors and date of birth mandatory")
   void testValidateOpponents_WithIndividualOpponentErrors_DateOfBirthMandatory() {
     final IndividualOpponentFormData opponent = new IndividualOpponentFormData();
     opponent.setRelationshipToCase("CHILD");


### PR DESCRIPTION
This pull request refines the validation logic for individual opponents in the application submission process, specifically improving how the "date of birth mandatory" flag is determined based on the selected relationship to the case. The changes ensure that this flag is set accurately during validation and are accompanied by enhanced unit tests to verify the new logic.

**Validation logic improvements:**

* The `validateOpponents` method in `ApplicationSubmissionController` now determines if the date of birth is mandatory for each `IndividualOpponentFormData` by consulting the relevant `RelationshipToCaseLookupValueDetail` entries, ensuring the flag reflects the correct business rules. 
* Introduced a new method, `isIndividualDateOfBirthMandatory`, to encapsulate the logic for checking if date of birth is required based on the opponent's relationship to the case.

**Code reuse and simplification:**

* Refactored `OpponentsSectionController` to extract the logic for preparing an individual opponent for validation (including setting the date of birth mandatory flag and normalizing the date) into a new helper method, `prepareIndividualOpponentForValidation`, reducing code duplication. Calls to this logic in `createNewIndividual` and `editOpponent` now use the helper. 

**Unit test enhancements:**

* Updated and expanded tests in `ApplicationSubmissionControllerTest` to verify that the date of birth mandatory flag is set correctly for various relationships, using mock lookup data and argument captors to assert the flag's value during validation. 
* Added imports and setup for new lookup types and argument captors to support the enhanced tests. 